### PR TITLE
breaking: use clone_prefix and name instead of just URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Getting started
 
 In this example:
 
-* ``foo`` will be cloned in ``<workspace>/foo`` using ``git@example.co:proj1/foo.git`` origin url.
+* ``foo`` will be cloned in ``<workspace>/foo`` using ``git@example.com:proj1/foo.git`` origin url.
 * Similarly, ``bar`` will be cloned in ``<workspace>/bar`` using ``git@example.com:proj2/bar.git``
 * The file ``bar.txt`` will be copied from the ``bar`` repository to the
   top of the workspace, in ``<workspace>/top.txt``
@@ -61,7 +61,7 @@ Managing Merge Requests
     gitlab:
       url: http://gitlab.local
 
-* Create a ``~/.config/tsrc.yml``` looking like:
+* Create a ``~/.config/tsrc.yml`` looking like:
 
 .. code-block:: text
 

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@ tsrc
 
 Manage multiple git repos.
 
+Demo
+----
+
+`tsrc demo on asciinema.org <https://asciinema.org/a/131625>`_
+
 Tutorial
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ Manage multiple git repos.
 Tutorial
 ---------
 
+Getting started
++++++++++++++++
+
+
 * Install ``tsrc`` with ``pip install tsrc``
 
 * Create a *manifest* repository. (``git@example.org/manifest``)
@@ -45,22 +49,63 @@ In this example:
 * The file ``bar.txt`` will be copied from the ``bar`` repository to the
   top of the workspace, in ``<workspace>/top.txt``
 
+Managing Merge Requests
++++++++++++++++++++++++
+
+* Generate a token from GitLab
+
+* Add the *http* url to the manifest:
+
+.. code-block:: yaml
+
+    gitlab:
+      url: http://gitlab.local
+
+* Create a ``~/.netrc``` looking like:
+
+.. code-block:: text
+
+    machine gitlab login <login> password <token>
+
+* Make sure file is only readable by your user:
+
+.. code-block:: text
+
+    chmod 600 ~/.netrc
+
+
+
+* Start working on your branch
+
+* Create the pull request
+
+.. code-block:: console
+
+    $ tsrc push --assignee <an octive user>
+
+* When the review is done, tell GitLab to merge it once the CI passes
+
+.. code-block:: console
+
+    $ tsrc push --accept
+
 
 Differences with google repo
 -----------------------------
 
 Pros:
 
+* GitLab support
 * Nicer output
-* **GitLab** support
 * Uses mostly 'porcelain' commands from git, instead of relying on plumbings
   internals
 * Comprehensive test suite
 * Uses PEP8 coding style
 * Written in Python 3, not Python 2
 
-
 Missing features: (May be implemented in the future)
 
-* No ``-j`` option
-* No support for ``gerrit`` or ``github``
+* Cloning a specific branch, revision or tag
+* Cloning several repositories in parallel ``-j`` option
+* Cloning just one or several groups of repositories
+* Support for other hosting services such as ``gerrit`` or ``github``

--- a/README.rst
+++ b/README.rst
@@ -17,13 +17,14 @@ Tutorial
 
 .. code-block:: yaml
 
+    clone_prefix: git@example.com
 
     repos:
       - src: foo
-        url: git@example.com/foo.git
+        name: proj1/foo
 
       - src: bar
-        url: git@example.com/bar.git
+        name: proj2/bar
         copy:
           - src: bar.txt
             dest: top.txt
@@ -39,8 +40,8 @@ Tutorial
 
 In this example:
 
-* ``foo`` will be cloned in ``<workspace>/foo``
-* ``bar`` will be cloned in ``<workspace>/bar``
+* ``foo`` will be cloned in ``<workspace>/foo`` using ``git@example.co:proj1/foo.git`` origin url.
+* Similarly, ``bar`` will be cloned in ``<workspace>/bar`` using ``git@example.com:proj2/bar.git``
 * The file ``bar.txt`` will be copied from the ``bar`` repository to the
   top of the workspace, in ``<workspace>/top.txt``
 
@@ -51,7 +52,7 @@ Differences with google repo
 Pros:
 
 * Nicer output
-* `GitLab` support
+* **GitLab** support
 * Uses mostly 'porcelain' commands from git, instead of relying on plumbings
   internals
 * Comprehensive test suite
@@ -62,4 +63,4 @@ Pros:
 Missing features: (May be implemented in the future)
 
 * No ``-j`` option
-* No support for ``gerrit``
+* No support for ``gerrit`` or ``github``

--- a/README.rst
+++ b/README.rst
@@ -61,18 +61,13 @@ Managing Merge Requests
     gitlab:
       url: http://gitlab.local
 
-* Create a ``~/.netrc``` looking like:
+* Create a ``~/.config/tsrc.yml``` looking like:
 
 .. code-block:: text
 
-    machine gitlab login <login> password <token>
-
-* Make sure file is only readable by your user:
-
-.. code-block:: text
-
-    chmod 600 ~/.netrc
-
+    auth:
+      gitlab:
+        token: <YOUR TOKEN>
 
 
 * Start working on your branch

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name="tsrc",
         "requests",
         "ruamel.yaml",
         "unidecode",
+        "xdg",
       ],
       entry_points={
         "console_scripts": [

--- a/tsrc/cli/push.py
+++ b/tsrc/cli/push.py
@@ -20,7 +20,7 @@ def get_token():
 def get_project_name(*, url, prefix):
     if not url.startswith(prefix):
         message = "Could not get project name name.\n"
-        message += "(prefix: %s, url: %s) " % (prefix, url)
+        message += "(Expecting: '%s' to start with '%s') " % (prefix, url)
         raise tsrc.Error(message)
     res = url[len(prefix):]
     if res.endswith(".git"):

--- a/tsrc/cli/push.py
+++ b/tsrc/cli/push.py
@@ -1,9 +1,9 @@
 """ Entry point for tsrc push """
 
-import netrc
 import unidecode
 
 from tsrc import ui
+import tsrc.config
 import tsrc.gitlab
 import tsrc.git
 import tsrc.cli
@@ -13,9 +13,8 @@ WIP_PREFIX = "WIP: "
 
 
 def get_token():
-    netrc_parser = netrc.netrc()
-    unused_login, unused_account, password = netrc_parser.authenticators("gitlab")
-    return password
+    config = tsrc.config.read()
+    return config["auth"]["gitlab"]["token"]
 
 
 def get_project_name(*, url, prefix):

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -1,0 +1,13 @@
+""" Parse tsrc config files """
+
+import xdg
+
+import path
+import ruamel.yaml
+
+
+def read(config_path=None):
+    if not config_path:
+        config_path = path.Path(xdg.XDG_CONFIG_HOME)
+        config_path = config_path.joinpath("tsrc.yml")
+    return ruamel.yaml.safe_load(config_path.text())

--- a/tsrc/git.py
+++ b/tsrc/git.py
@@ -81,6 +81,14 @@ def get_current_ref(working_path):
     return output
 
 
+def get_origin_url(working_path):
+    cmd = ("remote", "get-url", "origin")
+    status, output = run_git(working_path, *cmd, raises=False)
+    if status != 0:
+        raise GitCommandError(working_path, cmd, output=output)
+    return output
+
+
 def get_repo_root():
     working_path = path.Path(os.getcwd())
     cmd = ("rev-parse", "--show-toplevel")

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -1,4 +1,5 @@
 """ manifests for tsrc """
+
 import os
 
 import ruamel.yaml
@@ -17,14 +18,17 @@ class Manifest():
         self.repos = list()      # repos to clone
         self.copyfiles = list()  # files to copy
         self.gitlab = dict()
+        self.clone_prefix = None
 
     def load(self, contents):
         self.copyfiles = list()
         parsed = ruamel.yaml.safe_load(contents) or dict()
         self.gitlab = parsed.get("gitlab")
+        self.clone_prefix = parsed["clone_prefix"]
+
         repos = parsed.get("repos") or list()
         for repo in repos:
-            repo_url = repo["url"]
+            repo_url = joinurl(self.clone_prefix, repo["name"])
             repo_src = repo["src"]
             self.repos.append((repo_src, repo_url))
             if "copy" in repo:
@@ -38,3 +42,35 @@ class Manifest():
             if repo_src == src:
                 return repo_url
         raise RepoNotFound(src)
+
+
+def joinurl(prefix, name):
+    res = None
+    if os.path.exists(prefix):
+        res = os.path.join(prefix, name)
+    elif has_scheme(prefix):
+        res = join_with(prefix, name, "/")
+    else:
+        # Assume simple ssh URL like git@host:path, or just host:path
+        res = join_with(prefix, name, ":")
+    if not res.endswith(".git"):
+        res += ".git"
+    return res
+
+
+def join_with(prefix, name, joiner):
+    if not prefix.endswith(joiner):
+        prefix += joiner
+    return prefix + name
+
+
+def has_scheme(url):
+    """
+    >>> has_scheme('http://foo/bar')
+    True
+    >>> has_scheme('git+ssh://foo/bar')
+    True
+    >>> has_scheme('git@foo.com')
+    False
+    """
+    return "://" in url

--- a/tsrc/test/cli/test_init.py
+++ b/tsrc/test/cli/test_init.py
@@ -46,12 +46,11 @@ def test_init_maint_branch(tsrc_cli, git_server, workspace_path):
 def test_change_remote(tsrc_cli, git_server, workspace_path):
     git_server.add_repo("foo")
     tsrc_cli.run("init", git_server.manifest_url)
-    new_url = "git@example.com/foo"
-    git_server.change_repo_url("foo", new_url)
+    git_server.rename_repo("foo", "bar")
     tsrc_cli.run("init", git_server.manifest_url)
     foo_path = workspace_path.joinpath("foo")
     _, actual_url = tsrc.git.run_git(foo_path, "remote", "get-url", "origin", raises=False)
-    assert actual_url == new_url
+    assert "bar.git" in actual_url
 
 
 def test_copy_files(tsrc_cli, git_server, workspace_path):

--- a/tsrc/test/cli/test_push.py
+++ b/tsrc/test/cli/test_push.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 import tsrc.cli.push
+from tsrc.cli.push import get_project_name
 import tsrc.git
 import tsrc.gitlab
 
@@ -41,6 +42,7 @@ def push_args():
     args.force = False
     args.ready = None
     args.wip = None
+    args.workspace_path = None
     return args
 
 
@@ -50,6 +52,11 @@ def gitlab_mock():
     gl_mock.get_active_users.return_value = [JOHN, BART, TIMOTHEE, THEO]
     gl_mock.get_project_id = lambda x: PROJECT_IDS[x]
     return gl_mock
+
+
+def test_get_project_name():
+    clone_prefix = 'git@example.com:'
+    assert get_project_name(url='git@example.com:foo/bar.git', prefix=clone_prefix) == "foo/bar"
 
 
 def test_creating_merge_request(foo_path, tsrc_cli, gitlab_mock, push_args):

--- a/tsrc/test/test_config.py
+++ b/tsrc/test/test_config.py
@@ -1,0 +1,17 @@
+import textwrap
+
+import tsrc.config
+
+
+def test_read_config(tmp_path):
+    tsrc_yml_path = tmp_path.joinpath("tsrc.yml")
+    tsrc_yml_path.write_text(
+        textwrap.dedent(
+            """\
+            auth:
+              gitlab:
+                token: MY_SECRET_TOKEN
+            """)
+    )
+    config = tsrc.config.read(config_path=tsrc_yml_path)
+    assert config["auth"]["gitlab"]["token"] == "MY_SECRET_TOKEN"

--- a/tsrc/test/test_fixtures.py
+++ b/tsrc/test/test_fixtures.py
@@ -44,6 +44,14 @@ def test_can_configure_gitlab(tmp_path, git_server):
     assert manifest.gitlab["url"] == test_url
 
 
+def test_change_repo_name(workspace_path, git_server):
+    git_server.add_repo("proj1/foo")
+    git_server.rename_repo("proj1/foo", "proj2/foo")
+    manifest = read_remote_manifest(workspace_path, git_server)
+    name, url = manifest.repos[0]
+    assert url.endswith("proj2/foo.git")
+
+
 def test_git_server_add_repo_updates_manifest(workspace_path, git_server):
     git_server.add_repo("foo/bar")
     git_server.add_repo("spam/eggs")

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -1,6 +1,7 @@
 import os.path
 
 import tsrc.manifest
+from tsrc.manifest import joinurl
 
 import pytest
 
@@ -8,23 +9,26 @@ import pytest
 def test_load():
     contents = """
 gitlab:
-  url: http://gitlab.example.com
+  http_url: http://gitlab.example.com
+
+clone_prefix: git@example.com
+
 repos:
   - src: foo
-    url: git@example.com:foo.git
+    name: proj/foo
 
   - src: master
-    url: git@example.com:master.git
+    name: proj/master
     copy:
       - src: top.cmake
         dest: CMakeLists.txt
 """
     manifest = tsrc.manifest.Manifest()
     manifest.load(contents)
-    assert manifest.gitlab["url"] == "http://gitlab.example.com"
+    assert manifest.gitlab["http_url"] == "http://gitlab.example.com"
     assert manifest.repos == [
-        ("foo", "git@example.com:foo.git"),
-        ("master", "git@example.com:master.git")
+        ("foo", "git@example.com:proj/foo.git"),
+        ("master", "git@example.com:proj/master.git")
     ]
     assert manifest.copyfiles == [
         (os.path.join("master", "top.cmake"), "CMakeLists.txt")
@@ -33,17 +37,34 @@ repos:
 
 def test_find():
     contents = """
+gitlab:
+  http_url: http://gitlab.example.com
+
+clone_prefix: ssh://git@example.com:8022
+
 repos:
   - src: foo
-    url: git@example.com:proj_one/foo
+    name: proj_one/foo
 
   - src: bar
-    url: git@example.com:proj_two/bar
+    name: proj_two/bar
 """
     manifest = tsrc.manifest.Manifest()
     manifest.load(contents)
-    assert manifest.get_url("foo") == "git@example.com:proj_one/foo"
-    assert manifest.get_url("bar") == "git@example.com:proj_two/bar"
+    assert manifest.get_url("foo") == "ssh://git@example.com:8022/proj_one/foo.git"
+    assert manifest.get_url("bar") == "ssh://git@example.com:8022/proj_two/bar.git"
     with pytest.raises(tsrc.manifest.RepoNotFound) as e:
         manifest.get_url("no/such")
         assert "no/such" in e.value.message
+
+
+def test_joinurl(git_server):
+    bar_url = git_server.add_repo("foo/bar")
+
+    test_data = [
+        (("git@example.com", "bar/baz"), "git@example.com:bar/baz.git"),
+        (("ssh://git@example.com:8022", "bar/baz"), "ssh://git@example.com:8022/bar/baz.git"),
+        ((git_server.clone_prefix, "foo/bar"), bar_url),
+    ]
+    for input_, output in test_data:
+        assert joinurl(*input_) == output

--- a/tsrc/workspace.py
+++ b/tsrc/workspace.py
@@ -135,3 +135,7 @@ class Workspace():
         """ Return the url of the project in `src` """
         manifest = self.load_manifest()
         return manifest.get_url(src)
+
+    def get_clone_prefix(self):
+        manifest = self.load_manifest()
+        return manifest.clone_prefix


### PR DESCRIPTION
Notes:

* We just replaced a heuristic (project_name_from_url()) by an
  other one: joinurl.

* We could get rid of the joinurl heuristic by requiring the
 `clone_prefix` variable to end with the correct separator but:
 * This is probably not what the users expect
 * YAML does not like strings ending with colons