### PR TITLE
Improve 'fix ref' handling: clone tag directly when possible, make the distinction between tags and sha1s

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+# next version
+
+*Breaking change*: improve fixed reference handling (#57).
+
+See the [dedicated section about manifest format](ref/formats.md#repos) for details.
+
 # v0.3.2 (2017-11-02)
 
 * Improve `tsrc status` to handle tags. Patch by @arnaudgelas

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -24,30 +24,44 @@ Each repository is also a dictionary, containing:
 * `url` (required): URL to use when cloning the repository (usually using ssh)
 * `branch` (optional): The branch to use when cloning the repository (defaults
   to `master`)
-* `fixed_ref` (optional): Can be a tag like `v0.1` or a hash like `0ab12ef`.
-   If `fixed_ref` is set:
-
-    *  When running `tsrc init`: Project will be cloned with the given branch, and then reset to
-        the given ref.
-    *  When running `tsrc sync`: If the project is clean, project will be reset
-        to the given ref, else a warning message will be printed.
-
+* `tag` (optional):
+    * When running `tsrc init`: Project will be cloned at the provided tag.
+    * When running `tsrc sync`:  If the project is clean, project will be reset
+        to the given tag, else a warning message will be printed.
+* `sha1` (optional):
+    * When running `tsrc init`: Project will be cloned, and then reset to the given sha1.
+    * When running `tsrc sync`:  If the project is clean, project will be reset
+        to the given sha1, else a warning message will be printed.
 * `copy`: (optional): A list of dictionaries with `src` and `dest` keys, like so:
 
 
 ```
 repos:
-  src: foo
-  url: gitlab:proj1/foo
-  branch: develop
-  copy:
-    - src: foo.txt
-      dest: top.txt
+  - src: foo
+    url: gitlab:proj1/foo
+    branch: next
+
+  - src: bar
+    url: gitlab:proj1/bar
+    branch: master
+    sha1: ad2b68539c78e749a372414165acdf2a1bb68203
+
+  - src: app
+    url: gitlab:proj1/app
+    tag: v0.1
+    copy:
+      - src: top.cmake
+        dest: CMakeLists.txt
+      - src: .clang-format
 ```
 
 In this case, after `proj1/foo` has been cloned in `<workspace>/foo`,
-(using `develop` branch), `foo.txt` will be copied from `proj1/foo/foo.txt` to
-`<workspace>/top.txt`. Note that `copy` only works with files, not directories.
+(using `next` branch). Then `proj1/bar` has been cloned in `<workspace>/bar`
+and reset to `ad2b68539c78e749a372414165acdf2a1bb68203`. Finally `proj1/app`
+has been cloned in `<workspace>/app` at on the tag `v0.1`, `top.cmake` will be
+copied from `proj1/app/top.cmake` to `<workspace>/CMakeLists.txt` and
+`proj1/app/.clang-format` to `<workspace>/.clang-format`.
+Note that `copy` only works with files, not directories.
 
 ## groups
 

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -23,7 +23,8 @@ def load(manifest_path):
         "url": str,
         schema.Optional("branch"): str,
         schema.Optional("copy"): [copy_schema],
-        schema.Optional("fixed_ref"): str,
+        schema.Optional("sha1"): str,
+        schema.Optional("tag"): str,
     }
     group_schema = {
         "repos": [str],
@@ -55,9 +56,10 @@ class Manifest():
             url = repo_config["url"]
             src = repo_config["src"]
             branch = repo_config.get("branch", "master")
-            fixed_ref = repo_config.get("fixed_ref")
+            tag = repo_config.get("tag")
+            sha1 = repo_config.get("sha1")
             repo = tsrc.Repo(url=url, src=src, branch=branch,
-                             fixed_ref=fixed_ref)
+                             sha1=sha1, tag=tag)
             self._repos.append(repo)
 
             self._handle_copies(repo_config)

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -9,4 +9,5 @@ class Repo():
     src = attr.ib()
     url = attr.ib()
     branch = attr.ib(default="master")
-    fixed_ref = attr.ib(default=None)
+    sha1 = attr.ib(default=None)
+    tag = attr.ib(default=None)

--- a/tsrc/test/cli/test_init.py
+++ b/tsrc/test/cli/test_init.py
@@ -96,11 +96,11 @@ def test_empty_repo(tsrc_cli, git_server, workspace_path):
     tsrc_cli.run("init", manifest_url, expect_fail=True)
 
 
-def test_resets_to_fixed_ref(tsrc_cli, git_server, workspace_path):
+def test_resets_to_tag(tsrc_cli, git_server, workspace_path):
     git_server.add_repo("foo")
     git_server.tag("foo", "v1.0")
     git_server.push_file("foo", "2.txt", message="Working on v2")
-    git_server.manifest.set_repo_ref("foo", "v1.0")
+    git_server.manifest.set_repo_tag("foo", "v1.0")
 
     manifest_url = git_server.manifest_url
     tsrc_cli.run("init", manifest_url)
@@ -109,6 +109,21 @@ def test_resets_to_fixed_ref(tsrc_cli, git_server, workspace_path):
     expected_ref = tsrc.git.run_git(foo_path, "rev-parse", "v1.0", raises=False)
     actual_ref = tsrc.git.run_git(foo_path, "rev-parse", "HEAD", raises=False)
     assert expected_ref == actual_ref
+
+
+def test_resets_to_sha1(tsrc_cli, git_server, workspace_path):
+    git_server.add_repo("foo")
+    initial_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", initial_sha1)
+
+    git_server.push_file("foo", "2.txt", message="Working on v2")
+
+    manifest_url = git_server.manifest_url
+    tsrc_cli.run("init", manifest_url)
+
+    foo_path = workspace_path.joinpath("foo")
+    rc, actual_ref = tsrc.git.run_git(foo_path, "rev-parse", "HEAD", raises=False)
+    assert initial_sha1 == actual_ref
 
 
 def test_use_default_group(tsrc_cli, git_server, workspace_path):

--- a/tsrc/test/cli/test_sync.py
+++ b/tsrc/test/cli/test_sync.py
@@ -127,10 +127,10 @@ def test_changing_branch(tsrc_cli, git_server, workspace_path, message_recorder)
     assert message_recorder.find("not on the correct branch")
 
 
-def test_fixed_ref_are_not_updated(tsrc_cli, git_server, workspace_path):
+def test_tags_are_not_updated(tsrc_cli, git_server, workspace_path):
     git_server.add_repo("foo")
     git_server.tag("foo", "v0.1")
-    git_server.manifest.set_repo_ref("foo", "v0.1")
+    git_server.manifest.set_repo_tag("foo", "v0.1")
 
     tsrc_cli.run("init", git_server.manifest_url)
 
@@ -142,17 +142,32 @@ def test_fixed_ref_are_not_updated(tsrc_cli, git_server, workspace_path):
     assert not foo_path.joinpath("new.txt").exists()
 
 
-def test_fixed_ref_are_updated_when_clean(tsrc_cli, git_server, workspace_path):
+def test_sha1s_are_not_updated(tsrc_cli, git_server, workspace_path):
+    git_server.add_repo("foo")
+    initial_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", initial_sha1)
+
+    tsrc_cli.run("init", git_server.manifest_url)
+
+    git_server.push_file("foo", "new.txt")
+
+    tsrc_cli.run("sync")
+
+    foo_path = workspace_path.joinpath("foo")
+    assert not foo_path.joinpath("new.txt").exists()
+
+
+def test_tags_are_updated_when_clean(tsrc_cli, git_server, workspace_path):
 
     git_server.add_repo("foo")
     git_server.tag("foo", "v0.1")
-    git_server.manifest.set_repo_ref("foo", "v0.1")
+    git_server.manifest.set_repo_tag("foo", "v0.1")
 
     tsrc_cli.run("init", git_server.manifest_url)
 
     git_server.push_file("foo", "new.txt")
     git_server.tag("foo", "v0.2")
-    git_server.manifest.set_repo_ref("foo", "v0.2")
+    git_server.manifest.set_repo_tag("foo", "v0.2")
 
     tsrc_cli.run("sync")
 
@@ -160,18 +175,52 @@ def test_fixed_ref_are_updated_when_clean(tsrc_cli, git_server, workspace_path):
     assert foo_path.joinpath("new.txt").exists()
 
 
-def test_fixed_ref_are_skipped_when_not_clean(tsrc_cli, git_server, workspace_path):
+def test_sha1s_are_updated_when_clean(tsrc_cli, git_server, workspace_path):
+    git_server.add_repo("foo")
+    initial_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", initial_sha1)
 
+    tsrc_cli.run("init", git_server.manifest_url)
+
+    git_server.push_file("foo", "new.txt")
+    new_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", new_sha1)
+
+    tsrc_cli.run("sync")
+
+    foo_path = workspace_path.joinpath("foo")
+    assert foo_path.joinpath("new.txt").exists()
+
+
+def test_tags_are_skipped_when_not_clean(tsrc_cli, git_server, workspace_path):
     git_server.add_repo("foo")
     git_server.tag("foo", "v0.1")
-    git_server.manifest.set_repo_ref("foo", "v0.1")
+    git_server.manifest.set_repo_tag("foo", "v0.1")
 
     tsrc_cli.run("init", git_server.manifest_url)
     workspace_path.joinpath("foo", "untracked.txt").write_text("")
 
     git_server.push_file("foo", "new.txt")
     git_server.tag("foo", "v0.2")
-    git_server.manifest.set_repo_ref("foo", "v0.2")
+    git_server.manifest.set_repo_tag("foo", "v0.2")
+
+    tsrc_cli.run("sync", expect_fail=True)
+
+    foo_path = workspace_path.joinpath("foo")
+    assert not foo_path.joinpath("new.txt").exists()
+
+
+def test_tags_are_skipped_when_not_clean(tsrc_cli, git_server, workspace_path):
+    git_server.add_repo("foo")
+    initial_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", initial_sha1)
+
+    tsrc_cli.run("init", git_server.manifest_url)
+    workspace_path.joinpath("foo", "untracked.txt").write_text("")
+
+    git_server.push_file("foo", "new.txt")
+    new_sha1 = git_server.get_sha1("foo")
+    git_server.manifest.set_repo_sha1("foo", new_sha1)
 
     tsrc_cli.run("sync", expect_fail=True)
 

--- a/tsrc/test/helpers/git_server.py
+++ b/tsrc/test/helpers/git_server.py
@@ -56,8 +56,11 @@ class ManifestHandler():
     def set_repo_branch(self, src, branch):
         self.configue_repo(src, "branch", branch)
 
-    def set_repo_ref(self, src, ref):
-        self.configue_repo(src, "fixed_ref", ref)
+    def set_repo_sha1(self, src, ref):
+        self.configue_repo(src, "sha1", ref)
+
+    def set_repo_tag(self, src, tag):
+        self.configue_repo(src, "tag", tag)
 
     def set_repo_file_copies(self, src, copies):
         copy_dicts = list()
@@ -151,6 +154,11 @@ class GitServer():
         src_path = self.get_path(name)
         rc, out = tsrc.git.run_git(src_path, "branch", "--list", raises=False)
         return [x[2:].strip() for x in out.splitlines()]
+
+    def get_sha1(self, name):
+        src_path = self.get_path(name)
+        rc, out = tsrc.git.run_git(src_path, "rev-parse", "HEAD", raises=False)
+        return out
 
     def change_repo_branch(self, name, new_branch):
         src_path = self.get_path(name)

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -17,9 +17,14 @@ repos:
     url: git@example.com:foo.git
     branch: next
 
+  - src: bar
+    url: git@example.com:foo.git
+    branch: master
+    sha1: ad2b68539c78e749a372414165acdf2a1bb68203
+
   - src: master
     url: git@example.com:master.git
-    fixed_ref: v0.1
+    tag: v0.1
     copy:
       - src: top.cmake
         dest: CMakeLists.txt
@@ -34,13 +39,22 @@ repos:
             url="git@example.com:foo.git",
             src="foo",
             branch="next",
-            fixed_ref=None,
+            sha1=None,
+            tag=None
+        ),
+        tsrc.Repo(
+            url="git@example.com:foo.git",
+            src="bar",
+            branch="master",
+            sha1="ad2b68539c78e749a372414165acdf2a1bb68203",
+            tag=None
         ),
         tsrc.Repo(
             url="git@example.com:master.git",
             src="master",
             branch="master",
-            fixed_ref="v0.1"
+            sha1=None,
+            tag="v0.1",
         ),
     ]
     assert manifest.copyfiles == [


### PR DESCRIPTION
According to git documentation `git clone --branch <name>` can be used to clone
branches or a tags, see documentation:

	https://git-scm.com/docs/git-clone#git-clone--bltnamegt