### PR TITLE
Switch to tbump to bump tsrc releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[bumpversion]
-current_version = 0.3.2
-tag = true
-commit = true
-message = Bump to {new_version}
-
 [pycodestyle]
 exclude = build
 max-line-length = 100
-
-[bumpversion:file:setup.py]
-

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,22 @@
+[version]
+current = "0.3.2"
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (
+    -
+    (?P<channel>alpha|beta)
+    -
+    (?P<release>\d+)
+  )?
+'''
+
+[git]
+tag_template = "v{new_version}"
+message_template = "Bump to {new_version}"
+
+[[file]]
+src = "setup.py"


### PR DESCRIPTION
We need to be able to make 'beta' releases, and bumpversion
does not handle that well enough ...