### PR TITLE
No missing merge requests in "tsrc push" (fix issue #80)

### DIFF
--- a/tsrc/gitlab.py
+++ b/tsrc/gitlab.py
@@ -95,11 +95,14 @@ class GitLabHelper():
 
     def find_opened_merge_request(self, project_id, source_branch):
         url = "/projects/%s/merge_requests" % project_id
-        previous_mrs = self.make_request("GET", url)
+        params = {
+            "state": "opened",
+            "per_page": "100"
+        }
+        previous_mrs = self.make_request("GET", url, params=params)
         for mr in previous_mrs:
             if mr["source_branch"] == source_branch:
-                if mr["state"] == "opened":
-                    return mr
+                return mr
 
     def create_merge_request(self, project_id, source_branch, *, title,
                              target_branch="master"):


### PR DESCRIPTION
**Context:**

Merge requests are [paginated](https://gitlab.com/gitlab-org/gitlab-ce/blob/v10.4.2/lib/api/merge_requests.rb#L18) in [pages of 20 items](https://gitlab.com/gitlab-org/gitlab-ce/blob/v10.4.2/lib/api/pagination_params.rb#L19) by default in GitLab's API.

Pagination is configurable via requests parameters but cannot be disabled. The maximum number of items returned in 100 (<request>?per_page=100).

**What happened in issues #80?**

We only listed the latest 20 merge requests ordered by creation date desc (default sort).

If the merge request targeted by "tsrc push" was not in these latest 20, it was not found.

**How to fix it?**

First, we only need to GET merged requests with an "opened" state via the API. This was done with a post-request filtering, but there's a "state" parameter that can be used in the request instead.

Then, there's a [X-NEXT-PAGE](https://gitlab.com/gitlab-org/gitlab-ce/blob/v10.4.2/lib/api/helpers/pagination.rb#L19) header returned by GitLab's API on GET requests that we can follow to get all merge requests, page after page.

The commits of this merge request can be squashed. I kept them separate in case the complete fix is considered too complex and it is decided that supporting more than 100 opened merge requests is not necessary.