### PR TITLE
foreach: add a `--xfail` option

### DIFF
--- a/tsrc/cli/foreach.py
+++ b/tsrc/cli/foreach.py
@@ -16,14 +16,24 @@ class CommandFailed(tsrc.Error):
     pass
 
 
+class CommandSucceeded(tsrc.Error):
+    pass
+
+
 class CmdRunner(tsrc.Task[tsrc.Repo]):
     def __init__(
-        self, workspace_path: Path, cmd: List[str], cmd_as_str: str, shell: bool = False
+        self,
+        workspace_path: Path,
+        cmd: List[str],
+        cmd_as_str: str,
+        shell: bool = False,
+        expect_failure: bool = False,
     ) -> None:
         self.workspace_path = workspace_path
         self.cmd = cmd
         self.cmd_as_str = cmd_as_str
         self.shell = shell
+        self.expect_failure = expect_failure
 
     def display_item(self, repo: tsrc.Repo) -> str:
         return repo.src
@@ -32,7 +42,10 @@ class CmdRunner(tsrc.Task[tsrc.Repo]):
         ui.info_1("Running `%s` on %d repos" % (self.cmd_as_str, num_items))
 
     def on_failure(self, *, num_errors: int) -> None:
-        ui.error("Command failed for %s repo(s)" % num_errors)
+        if self.expect_failure:
+            ui.error("Command succeeded for %s repo(s)" % num_errors)
+        else:
+            ui.error("Command failed for %s repo(s)" % num_errors)
 
     def process(self, repo: tsrc.Repo) -> None:
         # fmt: off
@@ -43,15 +56,21 @@ class CmdRunner(tsrc.Task[tsrc.Repo]):
         # fmt: on
         full_path = self.workspace_path / repo.src
         rc = subprocess.call(self.cmd, cwd=full_path, shell=self.shell)
-        if rc != 0:
+        if rc != 0 and not self.expect_failure:
             raise CommandFailed()
+        if rc == 0 and self.expect_failure:
+            raise CommandSucceeded()
 
 
 def main(args: argparse.Namespace) -> None:
     workspace = tsrc.cli.get_workspace(args)
     workspace.load_manifest()
     cmd_runner = CmdRunner(
-        workspace.root_path, args.cmd, args.cmd_as_str, shell=args.shell
+        workspace.root_path,
+        args.cmd,
+        args.cmd_as_str,
+        shell=args.shell,
+        expect_failure=args.xfail,
     )
     manifest = workspace.local_manifest.manifest
     assert manifest

--- a/tsrc/cli/main.py
+++ b/tsrc/cli/main.py
@@ -122,6 +122,7 @@ def main_impl(args: ArgsList = None) -> None:
     foreach_parser.add_argument("cmd", nargs="*")
     foreach_parser.add_argument("-c", dest="shell", action="store_true")
     foreach_parser.add_argument("-g", "--group", action="append", dest="groups")
+    foreach_parser.add_argument("--xfail", action="store_true")
     foreach_parser.epilog = textwrap.dedent(
         """\
     Usage:

--- a/tsrc/test/cli/test_foreach.py
+++ b/tsrc/test/cli/test_foreach.py
@@ -115,3 +115,16 @@ def test_foreach_groups_warn_skipped(
 
     message_recorder.reset()
     tsrc_cli.run("foreach", "-g", "foo", "-g", "spam", *cmd)
+
+
+def test_foreach_xfail(
+    tsrc_cli: CLI, git_server: GitServer, message_recorder: MessageRecorder
+) -> None:
+    git_server.add_repo("foo")
+    git_server.add_repo("spam")
+    git_server.push_file("foo", "new.txt")
+    manifest_url = git_server.manifest_url
+    tsrc_cli.run("init", manifest_url)
+
+    tsrc_cli.run("foreach", "--xfail", "ls", "new.txt", expect_fail=True)
+    assert message_recorder.find("Command succeeded")


### PR DESCRIPTION
For instance, to check a file is *absent*,
you may run:

`tsrc foreach --xfail ls <the-file>`