### PR TITLE
Refreshing dmenv command to extract venv_path doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ $ dmenv install
 * Finally, run:
 
 ```console
-$ source "$(dmenv show)/bin/activate"
+$ source "$(dmenv show:venv_path)/bin/activate"
 $ python ci/ci.py
 ```
 


### PR DESCRIPTION
Just a documentation refresh as I run thru the CI checks

I installed a fresh version of dmenv and it appears that this version does not have a `dmenv show` but instead has various modifiers it appears to me that `dmenv show:venv_path` is the right way to go forward.