### PR TITLE
Add GitHub Enterprise support + Git push fallback

### DIFF
--- a/docs/guide/review.md
+++ b/docs/guide/review.md
@@ -1,6 +1,6 @@
 `tsrc` can automate part of the code review process.
 
-You can use it with GitLab or GitHub repositories.
+You can use it with GitLab, GitHub, GitHub Enterprise, or standard Git repositories.
 
 # Handling GitLab merge requests
 
@@ -50,9 +50,20 @@ the CI pipeline passes with the following command:
 $ tsrc push --accept
 ```
 
-# Handling GitHub pull requests
+# Handling GitHub & GitHub Enterprise pull requests
 
 If there is a remote named `origin` and starting with `git@github.com`, `tsrc` will assume you want to use GitHub.
+
+Alternatively, if GitHub Enterprise is configured in the *manifest* file such as:
+
+```yaml
+github_enterprise:
+  url: http://github.local
+
+repos:
+ - ...
+```
+and there is a remote named `origin` which starts with `git@github.local` (hostname of `github_enterprise.url` configuration) , `tsrc` will assume you want to use GitHub Enterprise.
 
 Then, the first time you need access to GitHub API, it will ask for your credentials, generate a token and store it in the `~/.config/tsrc.yml` file.
 
@@ -85,3 +96,8 @@ $ tsrc push --close
 # Merge
 $ tsrc push --merge
 ```
+
+# Handling standard Git repositories
+
+If `tsrc` can't determine to use GitLab, GitHub, or GitHub Enterprise it will push the changes to the remote repository 
+without creating any pull requests on the user's behalf.

--- a/docs/guide/review.md
+++ b/docs/guide/review.md
@@ -66,6 +66,12 @@ repos:
 and there is a remote named `origin` which starts with `git@github.local` (hostname of `github_enterprise.url` configuration) , `tsrc` will assume you want to use GitHub Enterprise.
 
 Then, the first time you need access to GitHub API, it will ask for your credentials, generate a token and store it in the `~/.config/tsrc.yml` file.
+In the event your GitHub Enterprise instance has a self-signed certificate the trust store can be configured in the `~/.config/tsrc.yml` file via:
+```yaml
+auth:
+  github_enterprise:
+    verify: <path to your crt file e.g. /etc/pki/tls/certs/ca-bundle.crt | false to disable verification>
+```
 
 ## Creating a pull request
 

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -14,6 +14,8 @@ The manifest is always parsed as a dictionary.
 
 * `gitlab.url` (optional): HTTP URL of the GitLab instance
 
+* `github_enterprise.url` (optional): HTTP URL of the Github Enterprise instance
+
 * `groups` (optional): list of groups
 
 ### repos

--- a/tsrc/cli/push.py
+++ b/tsrc/cli/push.py
@@ -12,19 +12,22 @@ import cli_ui as ui
 
 import tsrc
 import tsrc.git
+import tsrc.cli
 
 
 def service_from_url(url: str, workspace: tsrc.Workspace) -> str:
     if url.startswith("git@github.com"):
         return "github"
 
-    if workspace.get_github_enterprise_url():
-        github_domain = urlparse(workspace.get_github_enterprise_url()).hostname
+    github_enterprise_url = workspace.get_github_enterprise_url()
+    if github_enterprise_url:
+        github_domain = urlparse(github_enterprise_url).hostname
         if url.startswith("git@%s" % github_domain):
             return "github_enterprise"
 
-    if workspace.get_gitlab_url():
-        gitlab_domain = urlparse(workspace.get_gitlab_url()).hostname
+    gitlab_url = workspace.get_gitlab_url()
+    if gitlab_url:
+        gitlab_domain = urlparse(gitlab_url).hostname
         if url.startswith("git@%s" % gitlab_domain):
             return "gitlab"
 
@@ -60,7 +63,9 @@ class RepositoryInfo:
         self.repository_login_url = None  # type: Optional[str]
         self.read_working_path(workspace=workspace, working_path=working_path)
 
-    def read_working_path(self, workspace: tsrc.Workspace, working_path: Path = None) -> None:
+    def read_working_path(
+        self, workspace: tsrc.Workspace, working_path: Path = None
+    ) -> None:
         self.path = tsrc.git.get_repo_root(working_path=working_path)
         self.current_branch = tsrc.git.get_current_branch(self.path)
         rc, out = tsrc.git.run_captured(

--- a/tsrc/cli/push.py
+++ b/tsrc/cli/push.py
@@ -5,6 +5,7 @@ import argparse
 import importlib
 import re
 from typing import cast, Iterable, Optional
+from urllib.parse import urlparse
 
 from path import Path
 import cli_ui as ui
@@ -13,18 +14,21 @@ import tsrc
 import tsrc.git
 
 
-def service_from_url(url: str) -> str:
-    """
-    >>> service_from_url("git@github.com:foo/bar")
-    'github'
-    >>> service_from_url("git@gitlab.local:foo/bar")
-    'gitlab'
-
-    """
+def service_from_url(url: str, workspace: tsrc.Workspace) -> str:
     if url.startswith("git@github.com"):
         return "github"
-    else:
-        return "gitlab"
+
+    if workspace.get_github_enterprise_url():
+        github_domain = urlparse(workspace.get_github_enterprise_url()).hostname
+        if url.startswith("git@%s" % github_domain):
+            return "github_enterprise"
+
+    if workspace.get_gitlab_url():
+        gitlab_domain = urlparse(workspace.get_gitlab_url()).hostname
+        if url.startswith("git@%s" % gitlab_domain):
+            return "gitlab"
+
+    return "git"
 
 
 def project_name_from_url(url: str) -> str:
@@ -46,16 +50,17 @@ def project_name_from_url(url: str) -> str:
 
 
 class RepositoryInfo:
-    def __init__(self, working_path: Path = None) -> None:
+    def __init__(self, workspace: tsrc.Workspace, working_path: Path = None) -> None:
         self.project_name = None  # type: Optional[str]
         self.url = None  # type: Optional[str]
         self.path = None  # type: Optional[Path]
         self.current_branch = None  # type: Optional[str]
         self.service = None  # type: Optional[str]
         self.tracking_ref = None  # type: Optional[str]
-        self.read_working_path(working_path=working_path)
+        self.repository_login_url = None  # type: Optional[str]
+        self.read_working_path(workspace=workspace, working_path=working_path)
 
-    def read_working_path(self, working_path: Path = None) -> None:
+    def read_working_path(self, workspace: tsrc.Workspace, working_path: Path = None) -> None:
         self.path = tsrc.git.get_repo_root(working_path=working_path)
         self.current_branch = tsrc.git.get_current_branch(self.path)
         rc, out = tsrc.git.run_captured(
@@ -67,7 +72,12 @@ class RepositoryInfo:
             return
         self.tracking_ref = tsrc.git.get_tracking_ref(self.path)
         self.project_name = project_name_from_url(self.url)
-        self.service = service_from_url(self.url)
+        self.service = service_from_url(url=self.url, workspace=workspace)
+
+        if self.service == "gitlab":
+            self.repository_login_url = workspace.get_gitlab_url()
+        elif self.service == "github_enterprise":
+            self.repository_login_url = workspace.get_github_enterprise_url()
 
 
 class PushAction(metaclass=abc.ABCMeta):
@@ -149,7 +159,10 @@ class PushAction(metaclass=abc.ABCMeta):
 
 
 def main(args: argparse.Namespace) -> None:
-    repository_info = RepositoryInfo()
+    workspace = tsrc.cli.get_workspace(args)
+    workspace.load_manifest()
+
+    repository_info = RepositoryInfo(workspace)
     service_name = repository_info.service
     module = importlib.import_module("tsrc.cli.push_%s" % service_name)
     push_action = module.PushAction(repository_info, args)  # type: ignore

--- a/tsrc/cli/push_git.py
+++ b/tsrc/cli/push_git.py
@@ -1,0 +1,21 @@
+""" Ability to push to a standard Git system without requiring Github or Gitlab.
+    No pull requests will be automatically created. """
+
+import argparse
+import tsrc.git
+from tsrc.cli.push import RepositoryInfo
+
+
+class PushAction(tsrc.cli.push.PushAction):
+    def __init__(
+        self,
+        repository_info: RepositoryInfo,
+        args: argparse.Namespace
+    ) -> None:
+        super().__init__(repository_info, args)
+
+    def setup_service(self) -> None:
+        pass
+
+    def post_push(self) -> None:
+        pass

--- a/tsrc/cli/push_git.py
+++ b/tsrc/cli/push_git.py
@@ -8,9 +8,7 @@ from tsrc.cli.push import RepositoryInfo
 
 class PushAction(tsrc.cli.push.PushAction):
     def __init__(
-        self,
-        repository_info: RepositoryInfo,
-        args: argparse.Namespace
+        self, repository_info: RepositoryInfo, args: argparse.Namespace
     ) -> None:
         super().__init__(repository_info, args)
 

--- a/tsrc/cli/push_github_enterprise.py
+++ b/tsrc/cli/push_github_enterprise.py
@@ -17,6 +17,6 @@ class PushAction(tsrc.cli.push_github.PushAction):
         github_api: Optional[GitHub] = None,
     ) -> None:
         if not github_api:
-            github_api = tsrc.github.login(github_enterprise_url=self.repository_info.repository_login_url)
+            github_api = tsrc.github.login(github_enterprise_url=repository_info.repository_login_url)
 
         super().__init__(repository_info, args, github_api)

--- a/tsrc/cli/push_github_enterprise.py
+++ b/tsrc/cli/push_github_enterprise.py
@@ -17,6 +17,8 @@ class PushAction(tsrc.cli.push_github.PushAction):
         github_api: Optional[GitHub] = None,
     ) -> None:
         if not github_api:
-            github_api = tsrc.github.login(github_enterprise_url=repository_info.repository_login_url)
+            github_api = tsrc.github.login(
+                github_enterprise_url=repository_info.repository_login_url
+            )
 
         super().__init__(repository_info, args, github_api)

--- a/tsrc/cli/push_github_enterprise.py
+++ b/tsrc/cli/push_github_enterprise.py
@@ -1,0 +1,22 @@
+import tsrc.cli.push_github
+import argparse
+from typing import Optional
+
+from github3 import GitHub
+
+import tsrc
+import tsrc.github
+from tsrc.cli.push import RepositoryInfo
+
+
+class PushAction(tsrc.cli.push_github.PushAction):
+    def __init__(
+        self,
+        repository_info: RepositoryInfo,
+        args: argparse.Namespace,
+        github_api: Optional[GitHub] = None,
+    ) -> None:
+        if not github_api:
+            github_api = tsrc.github.login(github_enterprise_url=self.repository_info.repository_login_url)
+
+        super().__init__(repository_info, args, github_api)

--- a/tsrc/cli/push_gitlab.py
+++ b/tsrc/cli/push_gitlab.py
@@ -80,11 +80,8 @@ class PushAction(tsrc.cli.push.PushAction):
 
     def setup_service(self) -> None:
         if not self.gitlab_api:
-            workspace = tsrc.cli.get_workspace(self.args)
-            workspace.load_manifest()
-            gitlab_url = workspace.get_gitlab_url()
             token = get_token()
-            self.gitlab_api = Gitlab(gitlab_url, private_token=token)
+            self.gitlab_api = Gitlab(self.repository_info.repository_login_url, private_token=token)
 
         assert self.project_name
         self.project = self.gitlab_api.projects.get(self.project_name)

--- a/tsrc/cli/push_gitlab.py
+++ b/tsrc/cli/push_gitlab.py
@@ -81,7 +81,9 @@ class PushAction(tsrc.cli.push.PushAction):
     def setup_service(self) -> None:
         if not self.gitlab_api:
             token = get_token()
-            self.gitlab_api = Gitlab(self.repository_info.repository_login_url, private_token=token)
+            self.gitlab_api = Gitlab(
+                self.repository_info.repository_login_url, private_token=token
+            )
 
         assert self.project_name
         self.project = self.gitlab_api.projects.get(self.project_name)

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -16,6 +16,9 @@ def parse_config(
     config_schema: Optional[schema.Schema] = None,
     roundtrip: bool = False,
 ) -> Config:
+    if not file_path.exists():
+        dump_config({"auth": {}}, file_path)
+
     try:
         contents = file_path.text()
     except OSError as os_error:
@@ -57,6 +60,7 @@ def parse_tsrc_config(config_path: Path = None, roundtrip: bool = False) -> Conf
     auth_schema = {
         schema.Optional("gitlab"): {"token": str},
         schema.Optional("github"): {"token": str},
+        schema.Optional("github_enterprise"): {"token": str},
     }
     tsrc_schema = schema.Schema({"auth": auth_schema})
     if not config_path:

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -60,7 +60,7 @@ def parse_tsrc_config(config_path: Path = None, roundtrip: bool = False) -> Conf
     auth_schema = {
         schema.Optional("gitlab"): {"token": str},
         schema.Optional("github"): {"token": str},
-        schema.Optional("github_enterprise"): {"token": str},
+        schema.Optional("github_enterprise"): {"token": str, schema.Optional("verify"): object},
     }
     tsrc_schema = schema.Schema({"auth": auth_schema})
     if not config_path:

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -61,7 +61,7 @@ def parse_tsrc_config(config_path: Path = None, roundtrip: bool = False) -> Conf
         schema.Optional("gitlab"): {"token": str},
         schema.Optional("github"): {"token": str},
         schema.Optional("github_enterprise"): {
-            "token": str,
+            schema.Optional("token"): str,
             schema.Optional("verify"): object,
         },
     }

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -17,7 +17,7 @@ def parse_config(
     roundtrip: bool = False,
 ) -> Config:
     if not file_path.exists():
-        dump_config({"auth": {}}, file_path)
+        dump_config(Config({"auth": {}}), file_path)
 
     try:
         contents = file_path.text()
@@ -60,7 +60,10 @@ def parse_tsrc_config(config_path: Path = None, roundtrip: bool = False) -> Conf
     auth_schema = {
         schema.Optional("gitlab"): {"token": str},
         schema.Optional("github"): {"token": str},
-        schema.Optional("github_enterprise"): {"token": str, schema.Optional("verify"): object},
+        schema.Optional("github_enterprise"): {
+            "token": str,
+            schema.Optional("verify"): object,
+        },
     }
     tsrc_schema = schema.Schema({"auth": auth_schema})
     if not config_path:

--- a/tsrc/github.py
+++ b/tsrc/github.py
@@ -80,7 +80,7 @@ def save_token(token: str, auth_system: str) -> None:
     if "auth" not in config:
         config["auth"] = dict()
     auth = config["auth"]
-    if auth_system not in config:
+    if auth_system not in auth:
         auth[auth_system] = dict()
     auth[auth_system]["token"] = token
     tsrc.config.dump_tsrc_config(config)

--- a/tsrc/github.py
+++ b/tsrc/github.py
@@ -2,7 +2,7 @@
 
 import getpass
 import uuid
-from typing import cast, List, Optional
+from typing import cast, List, Optional, Dict, Any
 
 import github3
 from github3.repos.repo import Repository
@@ -22,12 +22,12 @@ class GitHubAPIError(tsrc.Error):
         return "%s - %s" % (self.status_code, self.message)
 
 
-def get_config_auth_object(auth_system: str) -> Optional[str]:
+def get_config_auth_object(auth_system: str) -> Dict[str, Any]:
     config = tsrc.config.parse_tsrc_config()
     auth = config.get("auth")
     if not auth:
-        return None
-    return cast(Optional[str], auth.get(auth_system, None))
+        return dict()
+    return cast(Dict[str, Any], auth.get(auth_system, dict()))
 
 
 def get_previous_token(auth_system: str) -> Optional[str]:

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -13,6 +13,7 @@ ManifestConfig = NewType("ManifestConfig", Dict[str, Any])
 RepoConfig = NewType("RepoConfig", Dict[str, Any])
 
 GitLabConfig = NewType("GitLabConfig", Dict[str, Any])
+GithubEnterpriseConfig = NewType("GithubEnterpriseConfig", Dict[str, Any])
 
 
 class RepoNotFound(tsrc.Error):
@@ -25,11 +26,13 @@ class Manifest:
         self._repos = list()  # type: List[tsrc.Repo]
         self.copyfiles = list()  # type: List[Tuple[str, str]]
         self.gitlab = None  # type: Optional[GitLabConfig]
+        self.github_enterprise = None  # type: Optional[GithubEnterpriseConfig]
         self.group_list = None  # type:  Optional[tsrc.GroupList[str]]
 
     def load(self, config: ManifestConfig) -> None:
         self.copyfiles = list()
         self.gitlab = config.get("gitlab")
+        self.github_enterprise = config.get("github_enterprise")
         repos = config.get("repos") or list()
         for repo_config in repos:
             self._handle_repo(repo_config)
@@ -142,13 +145,14 @@ def validate_repo(data: Any) -> None:
 
 
 def load(manifest_path: Path) -> Manifest:
-    gitlab_schema = {"url": str}
+    remote_git_server_schema = {"url": str}
     repo_schema = schema.Use(validate_repo)
     group_schema = {"repos": [str], schema.Optional("includes"): [str]}
     manifest_schema = schema.Schema(
         {
             "repos": [repo_schema],
-            schema.Optional("gitlab"): gitlab_schema,
+            schema.Optional("gitlab"): remote_git_server_schema,
+            schema.Optional("github_enterprise"): remote_git_server_schema,
             schema.Optional("groups"): {str: group_schema},
         }
     )

--- a/tsrc/test/cli/test_push.py
+++ b/tsrc/test/cli/test_push.py
@@ -36,25 +36,25 @@ def test_push_use_given_push_spec(
 def test_service_from_url() -> None:
     workspace_mock = mock_workspace_git_urls()
 
-    assert "github" == tsrc.cli.push.service_from_url("git@github.com:TankerHQ/tsrc.git", workspace_mock)
-    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock)
-    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git",
-                                                                 workspace_mock)
-    assert "git" == tsrc.cli.push.service_from_url("git@git.example.com:TankerHQ/tsrc.git", workspace_mock)
+    assert tsrc.cli.push.service_from_url("git@github.com:TankerHQ/tsrc.git", workspace_mock) == "github"
+    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
+    assert tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git", workspace_mock) \
+        == "github_enterprise"
+    assert tsrc.cli.push.service_from_url("git@git.example.com:TankerHQ/tsrc.git", workspace_mock) == "git"
 
     workspace_mock.get_github_enterprise_url.return_value = "https://github.example.com:8443/github"
     workspace_mock.get_gitlab_url.return_value = "https://gitlab.example.com:8443/gitlab"
-    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock)
-    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git",
-                                                                 workspace_mock)
-    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:8443:TankerHQ/tsrc.git", workspace_mock)
-    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:8443:TankerHQ/tsrc.git",
-                                                                 workspace_mock)
+    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
+    assert tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git", workspace_mock) \
+        == "github_enterprise"
+    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:8443:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
+    assert tsrc.cli.push.service_from_url("git@github.example.com:8443:TankerHQ/tsrc.git", workspace_mock) \
+        == "github_enterprise"
 
 
 def test_project_name_from_url() -> None:
-    assert "foo/bar" == tsrc.cli.push.project_name_from_url('git@example.com:foo/bar.git')
-    assert "foo/bar" == tsrc.cli.push.project_name_from_url('ssh://git@example.com:8022/foo/bar.git')
+    assert tsrc.cli.push.project_name_from_url('git@example.com:foo/bar.git') == "foo/bar"
+    assert tsrc.cli.push.project_name_from_url('ssh://git@example.com:8022/foo/bar.git') == "foo/bar"
 
 
 def mock_workspace_git_urls() -> tsrc.Workspace:

--- a/tsrc/test/cli/test_push.py
+++ b/tsrc/test/cli/test_push.py
@@ -36,30 +36,35 @@ def test_push_use_given_push_spec(
 def test_service_from_url() -> None:
     workspace_mock = mock_workspace_git_urls()
 
-    assert tsrc.cli.push.service_from_url("git@github.com:TankerHQ/tsrc.git", workspace_mock) == "github"
-    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
-    assert tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git", workspace_mock) \
-        == "github_enterprise"
-    assert tsrc.cli.push.service_from_url("git@git.example.com:TankerHQ/tsrc.git", workspace_mock) == "git"
+    def get_service(url: str) -> str:
+        return tsrc.cli.push.service_from_url(url, workspace_mock)
 
-    workspace_mock.get_github_enterprise_url.return_value = "https://github.example.com:8443/github"
-    workspace_mock.get_gitlab_url.return_value = "https://gitlab.example.com:8443/gitlab"
-    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
-    assert tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git", workspace_mock) \
-        == "github_enterprise"
-    assert tsrc.cli.push.service_from_url("git@gitlab.example.com:8443:TankerHQ/tsrc.git", workspace_mock) == "gitlab"
-    assert tsrc.cli.push.service_from_url("git@github.example.com:8443:TankerHQ/tsrc.git", workspace_mock) \
-        == "github_enterprise"
+    assert get_service("git@github.com:TankerHQ/tsrc.git") == "github"
+    assert get_service("git@gitlab.ex.co:TankerHQ/tsrc.git") == "gitlab"
+    assert get_service("git@github.ex.co:TankerHQ/tsrc.git") == "github_enterprise"
+    assert get_service("git@git.ex.co:TankerHQ/tsrc.git") == "git"
+
+    workspace_mock.get_github_enterprise_url.return_value = (
+        "https://github.ex.co:8443/github"
+    )
+    workspace_mock.get_gitlab_url.return_value = "https://gitlab.ex.co:8443/gitlab"
+    assert get_service("git@gitlab.ex.co:TankerHQ/tsrc.git") == "gitlab"
+    assert get_service("git@github.ex.co:TankerHQ/tsrc.git") == "github_enterprise"
+    assert get_service("git@gitlab.ex.co:8443:TankerHQ/tsrc.git") == "gitlab"
+    assert get_service("git@github.ex.co:8443:TankerHQ/tsrc.git") == "github_enterprise"
 
 
 def test_project_name_from_url() -> None:
-    assert tsrc.cli.push.project_name_from_url('git@example.com:foo/bar.git') == "foo/bar"
-    assert tsrc.cli.push.project_name_from_url('ssh://git@example.com:8022/foo/bar.git') == "foo/bar"
+    def project_name(url: str) -> str:
+        return tsrc.cli.push.project_name_from_url(url)
+
+    assert project_name("git@ex.co:foo/bar.git") == "foo/bar"
+    assert project_name("ssh://git@ex.co:8022/foo/bar.git") == "foo/bar"
 
 
-def mock_workspace_git_urls() -> tsrc.Workspace:
-    workspace_mock = mock.Mock()
-    workspace_mock.get_github_enterprise_url.return_value = "https://github.example.com/"
-    workspace_mock.get_gitlab_url.return_value = "https://gitlab.example.com/"
+def mock_workspace_git_urls() -> mock.Mock:
+    workspace_mock = mock.Mock(tsrc.Workspace)
+    workspace_mock.get_github_enterprise_url.return_value = "https://github.ex.co/"
+    workspace_mock.get_gitlab_url.return_value = "https://gitlab.ex.co/"
 
     return workspace_mock

--- a/tsrc/test/cli/test_push.py
+++ b/tsrc/test/cli/test_push.py
@@ -1,16 +1,9 @@
 import argparse
+import mock
 
 from path import Path
 import tsrc
-from tsrc.cli.push import PushAction
-
-
-class DummyPush(PushAction):
-    def post_push(self) -> None:
-        pass
-
-    def setup_service(self) -> None:
-        pass
+from tsrc.cli.push_git import PushAction
 
 
 def test_push_use_tracked_branch(
@@ -18,8 +11,9 @@ def test_push_use_tracked_branch(
 ) -> None:
     tsrc.git.run(repo_path, "checkout", "-b", "local")
     tsrc.git.run(repo_path, "push", "-u", "origin", "local:remote")
-    repository_info = tsrc.cli.push.RepositoryInfo(repo_path)
-    dummy_push = DummyPush(repository_info, push_args)
+
+    repository_info = tsrc.cli.push.RepositoryInfo(mock_workspace_git_urls(), repo_path)
+    dummy_push = PushAction(repository_info, push_args)
     dummy_push.push()
     _, out = tsrc.git.run_captured(repo_path, "ls-remote")
     assert "local" not in out
@@ -31,9 +25,41 @@ def test_push_use_given_push_spec(
 ) -> None:
     tsrc.git.run(repo_path, "checkout", "-b", "local")
     push_args.push_spec = "local:remote"
-    repository_info = tsrc.cli.push.RepositoryInfo(repo_path)
-    dummy_push = DummyPush(repository_info, push_args)
+    repository_info = tsrc.cli.push.RepositoryInfo(mock_workspace_git_urls(), repo_path)
+    dummy_push = PushAction(repository_info, push_args)
     dummy_push.push()
     _, out = tsrc.git.run_captured(repo_path, "ls-remote")
     assert "local" not in out
     assert "heads/remote" in out
+
+
+def test_service_from_url() -> None:
+    workspace_mock = mock_workspace_git_urls()
+
+    assert "github" == tsrc.cli.push.service_from_url("git@github.com:TankerHQ/tsrc.git", workspace_mock)
+    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock)
+    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git",
+                                                                 workspace_mock)
+    assert "git" == tsrc.cli.push.service_from_url("git@git.example.com:TankerHQ/tsrc.git", workspace_mock)
+
+    workspace_mock.get_github_enterprise_url.return_value = "https://github.example.com:8443/github"
+    workspace_mock.get_gitlab_url.return_value = "https://gitlab.example.com:8443/gitlab"
+    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:TankerHQ/tsrc.git", workspace_mock)
+    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:TankerHQ/tsrc.git",
+                                                                 workspace_mock)
+    assert "gitlab" == tsrc.cli.push.service_from_url("git@gitlab.example.com:8443:TankerHQ/tsrc.git", workspace_mock)
+    assert "github_enterprise" == tsrc.cli.push.service_from_url("git@github.example.com:8443:TankerHQ/tsrc.git",
+                                                                 workspace_mock)
+
+
+def test_project_name_from_url() -> None:
+    assert "foo/bar" == tsrc.cli.push.project_name_from_url('git@example.com:foo/bar.git')
+    assert "foo/bar" == tsrc.cli.push.project_name_from_url('ssh://git@example.com:8022/foo/bar.git')
+
+
+def mock_workspace_git_urls() -> tsrc.Workspace:
+    workspace_mock = mock.Mock()
+    workspace_mock.get_github_enterprise_url.return_value = "https://github.example.com/"
+    workspace_mock.get_gitlab_url.return_value = "https://gitlab.example.com/"
+
+    return workspace_mock

--- a/tsrc/test/cli/test_push_github.py
+++ b/tsrc/test/cli/test_push_github.py
@@ -33,7 +33,12 @@ def execute_push(
 
 
 def test_create(
-    repo_path: Path, tsrc_cli: CLI, github_mock: Any, push_args: argparse.Namespace, git_server: GitServer, workspace_path: Path
+    repo_path: Path,
+    tsrc_cli: CLI,
+    github_mock: Any,
+    push_args: argparse.Namespace,
+    git_server: GitServer,
+    workspace_path: Path,
 ) -> None:
     mock_repo = mock.Mock()
     mock_repo.pull_requests.return_value = list()

--- a/tsrc/test/cli/test_push_github.py
+++ b/tsrc/test/cli/test_push_github.py
@@ -10,6 +10,7 @@ import tsrc
 from tsrc.test.helpers.cli import CLI
 from tsrc.cli.push import RepositoryInfo
 from tsrc.cli.push_github import PushAction
+from tsrc.test.helpers.git_server import GitServer
 
 
 @pytest.fixture
@@ -22,14 +23,17 @@ def github_mock() -> Any:
 def execute_push(
     repo_path: Path, push_args: argparse.Namespace, github_mock: Any
 ) -> None:
-    repository_info = RepositoryInfo()
-    repository_info.read_working_path(repo_path)
+    workspace_mock = mock.Mock()
+    workspace_mock.get_github_enterprise_url.return_value = None
+    workspace_mock.get_gitlab_url.return_value = None
+
+    repository_info = RepositoryInfo(workspace_mock, repo_path)
     push_action = PushAction(repository_info, push_args, github_api=github_mock)
     push_action.execute()
 
 
 def test_create(
-    repo_path: Path, tsrc_cli: CLI, github_mock: Any, push_args: argparse.Namespace
+    repo_path: Path, tsrc_cli: CLI, github_mock: Any, push_args: argparse.Namespace, git_server: GitServer, workspace_path: Path
 ) -> None:
     mock_repo = mock.Mock()
     mock_repo.pull_requests.return_value = list()

--- a/tsrc/test/cli/test_push_gitlab.py
+++ b/tsrc/test/cli/test_push_gitlab.py
@@ -58,8 +58,11 @@ def gitlab_mock_with_merge_requests(mock_merge_requests: List[Any]) -> Any:
 def execute_push(
     repo_path: Path, push_args: argparse.Namespace, gitlab_mock: Gitlab
 ) -> None:
-    repository_info = RepositoryInfo()
-    repository_info.read_working_path(repo_path)
+    workspace_mock = mock.Mock()
+    workspace_mock.get_github_enterprise_url.return_value = None
+    workspace_mock.get_gitlab_url.return_value = GITLAB_URL
+
+    repository_info = RepositoryInfo(workspace_mock, repo_path)
     push_action = PushAction(repository_info, push_args, gitlab_api=gitlab_mock)
     push_action.execute()
 

--- a/tsrc/test/helpers/git_server.py
+++ b/tsrc/test/helpers/git_server.py
@@ -49,6 +49,11 @@ class ManifestHandler:
         self.data["gitlab"]["url"] = url
         self.push("Add gitlab URL: %s" % url)
 
+    def configure_github_enterprise(self, *, url: str) -> None:
+        self.data["github_enterprise"] = dict()
+        self.data["github_enterprise"]["url"] = url
+        self.push("Add github_enterprise URL: %s" % url)
+
     def get_repo(self, src: str) -> RepoConfig:
         for repo in self.data["repos"]:
             if repo["src"] == src:

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -14,6 +14,8 @@ def test_load() -> None:
     contents = """
 gitlab:
   url: http://gitlab.example.com
+github_enterprise:
+  url: http://github.example.com
 repos:
   - src: foo
     url: git@example.com:foo.git
@@ -37,6 +39,8 @@ repos:
     manifest.load(parsed)
     assert manifest.gitlab
     assert manifest.gitlab["url"] == "http://gitlab.example.com"
+    assert manifest.github_enterprise
+    assert manifest.github_enterprise["url"] == "http://github.example.com"
     assert manifest.get_repos() == [
         tsrc.Repo(
             remotes=[tsrc.repo.Remote(name="origin", url="git@example.com:foo.git")],

--- a/tsrc/test/test_test_helpers.py
+++ b/tsrc/test/test_test_helpers.py
@@ -36,6 +36,14 @@ def test_can_configure_gitlab(tmp_path: Path, git_server: GitServer) -> None:
     assert manifest.gitlab["url"] == test_url
 
 
+def test_can_configure_github_enterprise(tmp_path: Path, git_server: GitServer) -> None:
+    test_url = "http://github.example.com"
+    git_server.manifest.configure_github_enterprise(url=test_url)
+    manifest = read_remote_manifest(tmp_path, git_server)
+    assert manifest.github_enterprise
+    assert manifest.github_enterprise["url"] == test_url
+
+
 def test_git_server_add_repo_updates_manifest(
     workspace_path: Path, git_server: GitServer
 ) -> None:

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -1,7 +1,7 @@
 """ Implementation of the tsrc Workspace: a collection of git repositories
 """
 
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Optional
 
 from path import Path
 
@@ -29,10 +29,10 @@ class Workspace:
     def load_manifest(self) -> None:
         self.local_manifest.load()
 
-    def get_gitlab_url(self) -> str:
+    def get_gitlab_url(self) -> Optional[str]:
         return self.local_manifest.get_gitlab_url()
 
-    def get_github_enterprise_url(self) -> str:
+    def get_github_enterprise_url(self) -> Optional[str]:
         return self.local_manifest.get_github_enterprise_url()
 
     def configure_manifest(self, manifest_config: ManifestConfig) -> None:

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -32,6 +32,9 @@ class Workspace:
     def get_gitlab_url(self) -> str:
         return self.local_manifest.get_gitlab_url()
 
+    def get_github_enterprise_url(self) -> str:
+        return self.local_manifest.get_github_enterprise_url()
+
     def configure_manifest(self, manifest_config: ManifestConfig) -> None:
         self.local_manifest.configure(manifest_config)
 

--- a/tsrc/workspace/local_manifest.py
+++ b/tsrc/workspace/local_manifest.py
@@ -51,15 +51,19 @@ class LocalManifest:
             raise tsrc.Error(message.format(yml_path))
         self.manifest = tsrc.manifest.load(yml_path)
 
-    def get_gitlab_url(self) -> str:
+    def get_gitlab_url(self) -> Optional[str]:
         assert self.manifest, "manifest is empty. Did you call load()?"
         gitlab_config = self.manifest.gitlab
-        return cast(str, gitlab_config.get("url", None)) if gitlab_config else None
+        if not gitlab_config:
+            return None
+        return cast(Optional[str], gitlab_config.get("url", None))
 
-    def get_github_enterprise_url(self) -> str:
+    def get_github_enterprise_url(self) -> Optional[str]:
         assert self.manifest, "manifest is empty. Did you call load()?"
         github_enterprise_config = self.manifest.github_enterprise
-        return cast(str, github_enterprise_config.get("url", None)) if github_enterprise_config else None
+        if not github_enterprise_config:
+            return None
+        return cast(Optional[str], github_enterprise_config.get("url", None))
 
     def configure(self, manifest_config: ManifestConfig) -> None:
         if not manifest_config.url and not manifest_config.file_path:

--- a/tsrc/workspace/local_manifest.py
+++ b/tsrc/workspace/local_manifest.py
@@ -54,9 +54,12 @@ class LocalManifest:
     def get_gitlab_url(self) -> str:
         assert self.manifest, "manifest is empty. Did you call load()?"
         gitlab_config = self.manifest.gitlab
-        if not gitlab_config:
-            raise tsrc.Error("No gitlab configuration found in manifest")
-        return cast(str, gitlab_config["url"])
+        return cast(str, gitlab_config.get("url", None)) if gitlab_config else None
+
+    def get_github_enterprise_url(self) -> str:
+        assert self.manifest, "manifest is empty. Did you call load()?"
+        github_enterprise_config = self.manifest.github_enterprise
+        return cast(str, github_enterprise_config.get("url", None)) if github_enterprise_config else None
 
     def configure(self, manifest_config: ManifestConfig) -> None:
         if not manifest_config.url and not manifest_config.file_path:


### PR DESCRIPTION
If a "review" mechanism isn't setup fallback to just standard git push command without creating pull requests.

This will support https://github.com/TankerHQ/tsrc/issues/132