### PR TITLE
Fix #196: FileCopier does not obey group rules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+# v1.0.1 - (2020-01-21)
+
+* Fix #196: Do not attempt file copies for non-cloned repos when using `tsrc init` with a list of groups.
+
 # v1.0.0 - (2020-01-09)
 
 Starting the new year with a stable release, at last!

--- a/tsrc/__init__.py
+++ b/tsrc/__init__.py
@@ -12,7 +12,7 @@ from .errors import Error, InvalidConfig  # noqa
 from .executor import Task, run_sequence, ExecutorFailed  # noqa
 from .groups import GroupList, Group  # noqa
 from .groups import GroupNotFound, UnknownElement as UnknownGroupElement  # noqa
-from .repo import Repo, Remote  # noqa
+from .repo import Repo, Remote, Copy  # noqa
 from .manifest import Manifest  # noqa
 from .manifest import load as load_manifest  # noqa
 from .workspace import Workspace  # noqa

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -1,8 +1,7 @@
 """ manifests for tsrc """
 
 import operator
-import os
-from typing import cast, Any, Dict, List, NewType, Optional, Tuple  # noqa
+from typing import cast, Any, Dict, List, Optional  # noqa
 
 from path import Path
 import schema
@@ -18,7 +17,6 @@ class RepoNotFound(tsrc.Error):
 class Manifest:
     def __init__(self) -> None:
         self._repos = []  # type: List[tsrc.Repo]
-        self.copyfiles = []  # type: List[Tuple[str, str]]
         self.group_list = None  # type:  Optional[tsrc.GroupList[str]]
         self.gitlab_url = None  # type: Optional[str]
         self.github_enterprise_url = None  # type: Optional[str]
@@ -28,7 +26,7 @@ class Manifest:
         # Note: we cannot just serialize the yaml file into the class,
         # because we need to convert the plain old dicts into
         # higher-level classes.
-        self.copyfiles = []
+        self.copyfiles = []  # type: List[tsrc.Copy]
         repos_config = config["repos"]
         for repo_config in repos_config:
             self._handle_repo(repo_config)
@@ -73,10 +71,10 @@ class Manifest:
             return
         to_cp = repo_config["copy"]
         for item in to_cp:
-            src_copy = item["src"]
-            dest_copy = item.get("dest", src_copy)
-            src_copy = os.path.join(repo_config["src"], src_copy)
-            self.copyfiles.append((src_copy, dest_copy))
+            src = item["src"]
+            dest = item.get("dest", src)
+            copy = tsrc.Copy(repo_config["src"], src, dest)
+            self.copyfiles.append(copy)
 
     def _handle_groups(self, groups_config: Any) -> None:
         elements = {repo.src for repo in self._repos}

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -11,6 +11,13 @@ class Remote:
 
 
 @attr.s(frozen=True)
+class Copy:
+    repo = attr.ib()  # type: str
+    src = attr.ib()  # type: str
+    dest = attr.ib()  # type: str
+
+
+@attr.s(frozen=True)
 class Repo:
     src = attr.ib()  # type: str
     branch = attr.ib(default="master")  # type: str

--- a/tsrc/test/cli/test_init.py
+++ b/tsrc/test/cli/test_init.py
@@ -180,9 +180,21 @@ def test_clone_all_repos(
 def test_use_specific_groups(
     tsrc_cli: CLI, git_server: GitServer, workspace_path: Path
 ) -> None:
+    """ Scenario:
+    * the manifest contains two groups, 'foo' and 'spam'
+    * the manifest contains one repo 'other'
+    * the 'other' repo is configured with a file copy
+
+    * the user runs `init --group foo, spam`
+
+    * we don't want 'other' to be cloned
+    * we don't want the file copy to be attempted
+    """
     git_server.add_group("foo", ["bar", "baz"])
     git_server.add_group("spam", ["eggs", "beacon"])
     git_server.add_repo("other")
+    git_server.push_file("other", "THANKS")
+    git_server.manifest.set_repo_file_copies("other", [("THANKS", "THANKS.copy")])
 
     manifest_url = git_server.manifest_url
     tsrc_cli.run("init", manifest_url, "--groups", "foo", "spam")

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 import textwrap
-import os.path
 
 import ruamel.yaml
 
@@ -63,8 +62,8 @@ repos:
         ),
     ]
     assert manifest.copyfiles == [
-        (os.path.join("master", "top.cmake"), "CMakeLists.txt"),
-        (os.path.join("master", ".clang-format"), ".clang-format"),
+        tsrc.Copy("master", "top.cmake", "CMakeLists.txt"),
+        tsrc.Copy("master", ".clang-format", ".clang-format"),
     ]
 
 

--- a/tsrc/test/test_test_helpers.py
+++ b/tsrc/test/test_test_helpers.py
@@ -25,7 +25,7 @@ def test_git_server_can_add_copies(workspace_path: Path, git_server: GitServer) 
     git_server.add_repo("foo")
     git_server.manifest.set_repo_file_copies("foo", [("foo.txt", "top.txt")])
     manifest = read_remote_manifest(workspace_path, git_server)
-    assert manifest.copyfiles == [("foo/foo.txt", "top.txt")]
+    assert manifest.copyfiles == [tsrc.Copy("foo", "foo.txt", "top.txt")]
 
 
 def test_can_configure_gitlab(tmp_path: Path, git_server: GitServer) -> None:

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -87,7 +87,8 @@ class Workspace:
         tsrc.executor.run_sequence(self.get_repos(), remote_setter)
 
     def copy_files(self) -> None:
-        file_copier = FileCopier(self.root_path)
+        repos = self.get_repos()
+        file_copier = FileCopier(self.root_path, repos)
         manifest = self.local_manifest.get_manifest()
         copyfiles = manifest.copyfiles
         tsrc.executor.run_sequence(copyfiles, file_copier)


### PR DESCRIPTION
Two steps:

* Introduce a real `Copy` type instead of the tuple
  (srt, dest) which contains the name of the repo.

* Skip non-cloned repos in the FileCopier executor.

Fix #196 