### PR TITLE
mypy: do not allow untyped decorators

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 mypy_path = stubs/
 files = tsrc/**/*.py
-disallow_untyped_decorators = false
+allow_untyped_decorators = false
 warn_unused_configs = true
 disallow_subclassing_any = true
 disallow_untyped_calls = true


### PR DESCRIPTION
This was copy/pasted from an other config file by mistake I guess