### PR TITLE
Preserves file attributes during copy step

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -6,6 +6,7 @@ Cédric Gestes
 Philippe Daouadi
 Dimitri Merejkowsky
 Théo Delrieu
+Jakob Heuser
 
 
 If you make a contribution, feel free to make a pull request to add your name

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Next release
 
 * Drop Python 3.5 support
+* Fix #217: Preserves file attributes during the `copy` statements in `repos`
 
 # v2.0.0 - (2020-04-06)
 

--- a/tsrc/test/cli/test_sync.py
+++ b/tsrc/test/cli/test_sync.py
@@ -145,18 +145,17 @@ def test_copies_are_up_to_date(
     assert (workspace_path / "top.txt").read_text() == "v2"
 
 
-def test_copies_are_readonly(
+def test_copies_preserve_stat(
     tsrc_cli: CLI, git_server: GitServer, workspace_path: Path
 ) -> None:
     manifest_url = git_server.manifest_url
     git_server.add_repo("foo")
-    git_server.push_file("foo", "foo.txt", contents="v1")
-    git_server.manifest.set_repo_file_copies("foo", [("foo.txt", "top.txt")])
+    git_server.push_file("foo", "foo.exe", contents="v1", executable=True)
+    git_server.manifest.set_repo_file_copies("foo", [("foo.exe", "top.exe")])
 
     tsrc_cli.run("init", manifest_url)
-
-    foo_txt = workspace_path / "top.txt"
-    assert not os.access(foo_txt, os.W_OK)
+    top_exe = workspace_path / "top.exe"
+    assert os.access(top_exe, os.X_OK)
 
 
 def test_changing_branch(

--- a/tsrc/test/helpers/git_server.py
+++ b/tsrc/test/helpers/git_server.py
@@ -47,7 +47,13 @@ class TestRepo:
         return ref
 
     def commit_file(
-        self, name: str, *, branch: str, contents: str, message: str
+        self,
+        name: str,
+        *,
+        branch: str,
+        contents: str,
+        message: str,
+        mode: int = pygit2.GIT_FILEMODE_BLOB
     ) -> pygit2.Tree:
         assert "/" not in name, "creating subtrees is not supported"
 
@@ -59,7 +65,7 @@ class TestRepo:
         old_tree = last_commit.tree
         tree_builder = self._repo.TreeBuilder(old_tree)
         blob_oid = self._repo.create_blob(contents.encode())
-        tree_builder.insert(name, blob_oid, pygit2.GIT_FILEMODE_BLOB)
+        tree_builder.insert(name, blob_oid, mode)
         new_tree = tree_builder.write()
 
         author = self.user
@@ -195,11 +201,22 @@ class GitServer:
         contents: str = "",
         message: str = "",
         branch: str = "master",
+        executable: bool = False
     ) -> None:
+        if executable:
+            file_mode = pygit2.GIT_FILEMODE_BLOB_EXECUTABLE
+        else:
+            file_mode = pygit2.GIT_FILEMODE_BLOB
         repo = self._get_repo(name)
         if not message:
             message = "add/update " + file_path
-        repo.commit_file(file_path, contents=contents, message=message, branch=branch)
+        repo.commit_file(
+            file_path,
+            contents=contents,
+            message=message,
+            branch=branch,
+            mode=file_mode
+        )
 
     def tag(
         self, name: str, tag_name: str, *, branch: str = "master", force: bool = False

--- a/tsrc/workspace/copier.py
+++ b/tsrc/workspace/copier.py
@@ -1,5 +1,4 @@
 from typing import List
-import stat
 
 import cli_ui as ui
 from path import Path
@@ -30,11 +29,6 @@ class FileCopier(tsrc.executor.Task[tsrc.Copy]):
         try:
             src_path = self.workspace_path / item.repo / item.src
             dest_path = self.workspace_path / item.dest
-            if dest_path.exists():
-                # Re-set the write permissions on the file:
-                dest_path.chmod(stat.S_IWRITE)
             src_path.copy(dest_path)
-            # Make sure perms are read only for everyone
-            dest_path.chmod(0o10444)
         except Exception as e:
             raise tsrc.Error(str(e))


### PR DESCRIPTION
**Summary** - This fixes #217 by doing a direct replacement using `path.copy`, which preserves attributes. If the file already exists and cannot be overwritten, then `tsrc` will fail similarly to copying a file that doesn't exist.

* [x] You follow indications from the code manifesto
* [x] All existing linters pass
* [x] All existing tests run
* [x] The new feature comes with appropriate tests
  * Updated the test performing a copy operation to copy a file with the "executable" mask on, checked against `os.X_OK`
* [x] update the changelog (in `docs/changelog.md`)
