### PR TITLE
Feature/selectable remotes

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -7,6 +7,7 @@ Philippe Daouadi
 Dimitri Merejkowsky
 Théo Delrieu
 Jakob Heuser
+Tronje Krabbe
 
 
 If you make a contribution, feel free to make a pull request to add your name

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 * Drop Python 3.5 support
 * Fix #217: Preserves file attributes during the `copy` statements in `repos`
+* `tsrc init` learned a `-r, --remote` option that pins the remote with the given name as the only remote to be used for cloning and syncing.
+  `tsrc` expects this remote to be present in the manifest for all repositories.
 
 # v2.0.0 - (2020-04-06)
 

--- a/docs/ref/cli.md
+++ b/docs/ref/cli.md
@@ -37,7 +37,7 @@ just at the top.
 ## Usage
 
 
-tsrc init MANIFEST_URL [--group GROUP1, GROUP2]
+tsrc init MANIFEST_URL [--group GROUP1, GROUP2] [--remote REMOTE]
 :   Initializes a new workspace.
 
     MANIFEST_URL should be a git URL containing a valid
@@ -50,6 +50,11 @@ tsrc init MANIFEST_URL [--group GROUP1, GROUP2]
 
     If you want to add or remove a group in your workspace, you can
     edit the configuration file in `<workspace>/.tsrc/config.yml`
+
+    The `-r,--remote` option can be used to set a fix remote to use when cloning
+    and syncing the repositories. If this flag is set, the remote from the manifest
+    with the given name will be used for all repos. It is an error if a repo
+    does not have this remote specified.
 
 
 tsrc foreach -- command --opt1 arg1

--- a/tsrc/cli/init.py
+++ b/tsrc/cli/init.py
@@ -26,6 +26,7 @@ def main(args: argparse.Namespace) -> None:
         clone_all_repos=args.clone_all_repos,
         repo_groups=args.groups,
         shallow_clones=args.shallow,
+        singular_remote=args.remote,
     )
 
     workspace_config.save_to_file(cfg_path)

--- a/tsrc/cli/main.py
+++ b/tsrc/cli/main.py
@@ -156,6 +156,12 @@ def main_impl(args: ArgsList = None) -> None:
     init_parser.add_argument(
         "-s", "--shallow", action="store_true", dest="shallow", default=False
     )
+    init_parser.add_argument(
+        "-r",
+        "--remote",
+        dest="remote",
+        help="Use only the remote with this name to clone repositories",
+    )
     init_parser.set_defaults(branch="master")
 
     log_parser = add_workspace_subparser(subparsers, "log")

--- a/tsrc/test/cli/test_init.py
+++ b/tsrc/test/cli/test_init.py
@@ -265,3 +265,25 @@ def test_several_remotes(
     )
     assert rc == 0, output
     assert output == "git@upstream.com"
+
+
+def test_singular_remote(
+    tsrc_cli: CLI, git_server: GitServer, workspace_path: Path
+) -> None:
+    foo_url = git_server.add_repo("foo")
+    # fmt: off
+    git_server.manifest.set_repo_remotes(
+        "foo",
+        [("origin", foo_url),
+         ("vpn", "foocrop.vpn/foo")])
+    # fmt: on
+
+    # only use "origin" remote
+    tsrc_cli.run("init", git_server.manifest_url, "-r", "origin")
+
+    foo_path = workspace_path / "foo"
+    _, output = tsrc.git.run_captured(
+        foo_path, "remote", "show", check=True
+    )
+
+    assert output == "origin"

--- a/tsrc/test/test_workspace_config.py
+++ b/tsrc/test/test_workspace_config.py
@@ -15,6 +15,7 @@ def test_save(tmp_path: Path) -> None:
         shallow_clones=True,
         repo_groups=["default", "a-team"],
         clone_all_repos=False,
+        singular_remote=None
     )
     persistent_path = tmp_path / "config.yml"
     config.save_to_file(persistent_path)

--- a/tsrc/workspace/config.py
+++ b/tsrc/workspace/config.py
@@ -15,6 +15,8 @@ class WorkspaceConfig:
     shallow_clones = attr.ib(default=False)  # type: bool
     clone_all_repos = attr.ib(default=False)  # type: bool
 
+    singular_remote = attr.ib(default=None)  # type: Optional[str]
+
     @manifest_url.validator
     def check(self, attribute: str, value: Optional[str] = None) -> None:
         if value is None:


### PR DESCRIPTION
Hi! I needed a tool that can manage the following use case:
* a set of repositories is hosted on two different remotes.
* depending on the physical location of a developer, they will want to clone all repos from exactly one of the two remotes.
* one of the remotes lives behind a VPN, forcing some developers, who don't have access, to always pick the other remote

`tsrc` came very close to solving this, but not quite. So I thought I'd add the feature.

This introduces the `-r,--remote` flag to `tsrc init`, which pins the remote with the given name as the only remote that is used for cloning and syncing. `tsrc` then expects this remote to be present for all repos in the manifest file.

Looking forward to your feedback! I'm not super confident with my commit order -- maybe it's better to keep things consistent and update the tests and docs after implementing the feature?
Anyway, thanks in advance!