### PR TITLE
Rewrite group handling

### DIFF
--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -1,11 +1,16 @@
 """ Common tools for tsrc commands """
 
+from typing import List
 import argparse
 import os
 
+import cli_ui as ui
 from path import Path
 
 import tsrc
+from tsrc.workspace.config import WorkspaceConfig
+from tsrc.workspace import Workspace
+from tsrc.manifest import Manifest
 
 
 def find_workspace_path() -> Path:
@@ -31,3 +36,55 @@ def get_workspace(args: argparse.Namespace) -> tsrc.Workspace:
     else:
         workspace_path = find_workspace_path()
     return tsrc.Workspace(workspace_path)
+
+
+def get_workspace_with_repos(args: argparse.Namespace) -> tsrc.Workspace:
+    workspace = get_workspace(args)
+    workspace.repos = resolve_repos(workspace, args=args)
+    return workspace
+
+
+def resolve_repos(workspace: Workspace, args: argparse.Namespace) -> List[tsrc.Repo]:
+    """"
+    Given a workspace with its config and its local manifest,
+    and a collection of parsed command  line arguments,
+    return the list of repositories to operate on.
+    """
+    # Handle --all-cloned and --groups
+    manifest = workspace.get_manifest()
+    if args.groups:
+        return manifest.get_repos(groups=args.groups)
+
+    if args.all_cloned:
+        repos = manifest.get_repos(all_=True)
+        return [repo for repo in repos if (workspace.root_path / repo.dest).exists()]
+
+    # At this point, nothing was requested on the command line, time to
+    # use the workspace configuration
+    return repos_from_config(manifest, workspace.config)
+
+
+def repos_from_config(
+    manifest: Manifest, workspace_config: WorkspaceConfig
+) -> List[tsrc.Repo]:
+    clone_all_repos = workspace_config.clone_all_repos
+    repo_groups = workspace_config.repo_groups
+
+    if clone_all_repos:
+        # workspace config contains clone_all_repos: true,
+        # return everything
+        return manifest.get_repos(all_=True)
+    if repo_groups:
+        # workspace config contains some groups, use that,
+        # fmt: off
+        ui.info(
+            ui.green, "*", ui.reset, "Using groups from workspace config:",
+            ", ".join(repo_groups),
+        )
+        # fmt: on
+        return manifest.get_repos(groups=repo_groups)
+    else:
+        # workspace config does not specify clone_all_repos nor
+        # a list of groups, ask the manifest for the list of default
+        # repos
+        return manifest.get_repos(groups=None)

--- a/tsrc/cli/apply_manifest.py
+++ b/tsrc/cli/apply_manifest.py
@@ -4,15 +4,15 @@ import argparse
 
 import cli_ui as ui
 import tsrc.cli
-from tsrc.workspace.local_manifest import LocalManifest
 
 
 def main(args: argparse.Namespace) -> None:
     workspace = tsrc.cli.get_workspace(args)
     manifest_path = args.manifest_path
-    ui.info_1("Applying manifest from", args.manifest_path)
 
-    workspace.local_manifest = LocalManifest(manifest_path.parent)
+    ui.info_1("Applying manifest from", args.manifest_path)
+    manifest = tsrc.manifest.load(manifest_path)
+    workspace.repos = tsrc.cli.repos_from_config(manifest, workspace.config)
     workspace.clone_missing()
     workspace.set_remotes()
     workspace.perform_filesystem_operations()

--- a/tsrc/cli/init.py
+++ b/tsrc/cli/init.py
@@ -6,6 +6,7 @@ from path import Path
 import cli_ui as ui
 
 import tsrc
+from tsrc.cli import repos_from_config
 from tsrc.workspace import Workspace
 from tsrc.workspace.config import WorkspaceConfig
 
@@ -33,6 +34,8 @@ def main(args: argparse.Namespace) -> None:
 
     workspace = Workspace(workspace_path)
     workspace.update_manifest()
+    manifest = workspace.get_manifest()
+    workspace.repos = repos_from_config(manifest, workspace_config)
     workspace.clone_missing()
     workspace.set_remotes()
     workspace.perform_filesystem_operations()

--- a/tsrc/cli/log.py
+++ b/tsrc/cli/log.py
@@ -9,9 +9,15 @@ import tsrc.cli
 
 
 def main(args: argparse.Namespace) -> None:
-    workspace = tsrc.cli.get_workspace(args)
+    workspace = tsrc.cli.get_workspace_with_repos(args)
     all_ok = True
-    for unused_index, repo, full_path in workspace.enumerate_repos():
+    for repo in workspace.repos:
+        full_path = workspace.root_path / repo.dest
+        if not full_path.exists():
+            ui.info(ui.bold, repo.dest, ": ", ui.red, "error: missing repo", sep="")
+            all_ok = False
+            continue
+
         colors = ["green", "reset", "yellow", "reset", "bold blue", "reset"]
         log_format = "%m {}%h{} - {}%d{} %s {}<%an>{}"
         log_format = log_format.format(*("%C({})".format(x) for x in colors))

--- a/tsrc/cli/main.py
+++ b/tsrc/cli/main.py
@@ -105,6 +105,11 @@ def main(args: ArgsList = None) -> None:
     main_impl(args=args)
 
 
+def add_group_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("-g", "--group", "--groups", nargs="+", dest="groups")
+    parser.add_argument("--all-cloned", action="store_true", dest="all_cloned")
+
+
 def main_impl(args: ArgsList = None) -> None:
     parser = argparse.ArgumentParser(prog="tsrc")
     parser.add_argument(
@@ -122,15 +127,9 @@ def main_impl(args: ArgsList = None) -> None:
     subparsers.add_parser("version")
 
     foreach_parser = add_workspace_subparser(subparsers, "foreach")
+    add_group_options(foreach_parser)
     foreach_parser.add_argument("cmd", nargs="*")
     foreach_parser.add_argument("-c", dest="shell", action="store_true")
-    foreach_parser.add_argument("-g", "--group", action="append", dest="groups")
-    foreach_parser.add_argument(
-        "--groups-from-config",
-        action="store_true",
-        help="Use groups from the workspace configuration",
-        default=False,
-    )
     foreach_parser.epilog = textwrap.dedent(
         """\
     Usage:
@@ -144,9 +143,9 @@ def main_impl(args: ArgsList = None) -> None:
     foreach_parser.formatter_class = argparse.RawDescriptionHelpFormatter
 
     init_parser = add_workspace_subparser(subparsers, "init")
+    add_group_options(init_parser)
     init_parser.add_argument("url")
     init_parser.add_argument("-b", "--branch")
-    init_parser.add_argument("-g", "--group", "--groups", nargs="+", dest="groups")
     init_parser.add_argument(
         "--clone-all-repos",
         action="store_true",
@@ -165,13 +164,16 @@ def main_impl(args: ArgsList = None) -> None:
     init_parser.set_defaults(branch="master")
 
     log_parser = add_workspace_subparser(subparsers, "log")
+    add_group_options(log_parser)
     log_parser.add_argument("--from", required=True, dest="from_", metavar="FROM")
     log_parser.add_argument("--to")
     log_parser.set_defaults(to="HEAD")
 
-    add_workspace_subparser(subparsers, "status")
+    status_parser = add_workspace_subparser(subparsers, "status")
+    add_group_options(status_parser)
 
     sync_parser = add_workspace_subparser(subparsers, "sync")
+    add_group_options(sync_parser)
     sync_parser.add_argument("--force", action="store_true")
 
     apply_manifest = add_workspace_subparser(subparsers, "apply-manifest")

--- a/tsrc/cli/status.py
+++ b/tsrc/cli/status.py
@@ -155,6 +155,6 @@ class StatusCollector(tsrc.Task[tsrc.Repo]):
 
 
 def main(args: argparse.Namespace) -> None:
-    workspace = tsrc.cli.get_workspace(args)
+    workspace = tsrc.cli.get_workspace_with_repos(args)
     status_collector = StatusCollector(workspace)
-    tsrc.run_sequence(workspace.get_repos(), status_collector)
+    tsrc.run_sequence(workspace.repos, status_collector)

--- a/tsrc/cli/sync.py
+++ b/tsrc/cli/sync.py
@@ -8,17 +8,11 @@ import tsrc.cli
 
 def main(args: argparse.Namespace) -> None:
     workspace = tsrc.cli.get_workspace(args)
+
     ui.info_2("Updating manifest")
     workspace.update_manifest()
 
-    config = workspace.config
-    groups = config.repo_groups
-    all_repos = config.clone_all_repos
-    if groups and not all_repos:
-        ui.info(ui.green, "*", ui.reset, "Using groups from config:", ", ".join(groups))
-    if all_repos:
-        ui.info(ui.green, "*", ui.reset, "Synchronizing all repos")
-
+    workspace.repos = tsrc.cli.resolve_repos(workspace, args=args)
     workspace.clone_missing()
     workspace.set_remotes()
     workspace.sync(force=args.force)

--- a/tsrc/groups.py
+++ b/tsrc/groups.py
@@ -37,7 +37,7 @@ class UnknownElement(GroupError):
     def __init__(self, group_name: str, element: T) -> None:
         self.group_name = group_name
         self.element = element
-        message = f"'{group_name}: unknown element: '{element}"
+        message = f"group '{group_name}': unknown element: '{element}'"
         super().__init__(message)
 
 

--- a/tsrc/test/cli/test_log.py
+++ b/tsrc/test/cli/test_log.py
@@ -45,3 +45,48 @@ def test_log_error(tsrc_cli: CLI, git_server: GitServer) -> None:
     tsrc_cli.run("init", manifest_url)
 
     tsrc_cli.run_and_fail("log", "--from", "v0.1")
+
+
+def test_use_given_group(tsrc_cli: CLI, git_server: GitServer) -> None:
+    """
+    Scenario:
+    * Create a manifest containing:
+      * a group named 'group1' containing the repo 'foo'
+      * a group named 'group2' containing the repo 'bar'
+    * Initialize a workspace from this manifest using the 'group1' and
+    'group2' groups
+    * Create a tag named v0.1 on foo
+    * Run `tsrc --log --from v0.1 --group group1`
+    """
+
+    git_server.add_group("group1", ["foo"])
+    git_server.add_group("group2", ["bar"])
+
+    manifest_url = git_server.manifest_url
+    git_server.tag("foo", "v0.1")
+    git_server.push_file("foo", "foo.txt", message="new foo!")
+
+    tsrc_cli.run("init", manifest_url, "--groups", "group1", "group2")
+    tsrc_cli.run("log", "--from", "v0.1", "--group", "group1")
+
+
+def test_missing_repos_from_given_group(
+    tsrc_cli: CLI, git_server: GitServer, message_recorder: MessageRecorder
+) -> None:
+    """
+    Scenario:
+    * Create a manifest with two disjoint groups, group1 and group2
+    * For each repo, create  v0.1 tag
+    * Initialize a workspace from this manifest using group1
+    * Run `tsrc log --from v0.1 --groups group1 group2`
+    * Check it fails
+    """
+    git_server.add_group("group1", ["foo"])
+    git_server.add_group("group2", ["bar"])
+    git_server.tag("foo", "v0.1")
+    git_server.tag("bar", "v0.1")
+    manifest_url = git_server.manifest_url
+    tsrc_cli.run("init", manifest_url, "--group", "group1")
+
+    message_recorder.reset()
+    tsrc_cli.run_and_fail("log", "--from", "v0.1", "--groups", "group1", "group2")

--- a/tsrc/test/test_resolve_repos.py
+++ b/tsrc/test/test_resolve_repos.py
@@ -1,0 +1,174 @@
+from typing import Any, Dict, List, Optional
+
+import argparse
+
+from path import Path
+import ruamel.yaml
+
+from tsrc.repo import Repo
+from tsrc.workspace import Workspace
+from tsrc.workspace.config import WorkspaceConfig
+from tsrc.cli import resolve_repos
+
+
+def create_manifest(
+    tmp_path: Path, *, repos: List[str], groups: Optional[Dict[str, Any]] = None
+) -> None:
+    config: Dict[str, Any] = {"repos": []}
+    if groups:
+        config["groups"] = groups
+    for name in repos:
+        config["repos"].append({"dest": name, "url": f"git@acme.org:{name}"})
+    manifest_path = tmp_path / ".tsrc/manifest"
+    manifest_path.makedirs_p()
+    dump_path = manifest_path / "manifest.yml"
+    dump_path.write_text(ruamel.yaml.dump(config))
+
+
+def create_workspace(
+    tmp_path: Path,
+    *,
+    repo_groups: Optional[List[str]] = None,
+    clone_all_repos: bool = False,
+) -> Workspace:
+    config = WorkspaceConfig(
+        manifest_url="git@acme.org/manifest.git",
+        manifest_branch="master",
+        shallow_clones=False,
+        clone_all_repos=clone_all_repos,
+        repo_groups=repo_groups or [],
+    )
+    config.save_to_file(tmp_path / ".tsrc" / "config.yml")
+    return Workspace(tmp_path)
+
+
+def new_args(
+    *, all_cloned: bool = False, groups: Optional[List[str]] = None
+) -> argparse.Namespace:
+    return argparse.Namespace(all_cloned=all_cloned, groups=groups)
+
+
+def repo_names(repos: List[Repo]) -> List[str]:
+    return [repo.dest for repo in repos]
+
+
+def test_no_args_no_config_no_default_group(tmp_path: Path) -> None:
+    """ Scenario:
+        * Nothing passed on the command line
+        * No default group in the manifest
+        * No workspace config
+
+        Should return all repos in the manifest
+        """
+    create_manifest(tmp_path, repos=["foo", "bar"])
+    workspace = create_workspace(tmp_path)
+    args = new_args()
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo", "bar"]
+
+
+def test_no_args_no_config_default_group(tmp_path: Path) -> None:
+    """ Scenario:
+        * Nothing passed on the command line
+        * A default group in the manifest containing 'foo'
+        * A repo named 'outside' in the manifest - not in any group
+        * No workspace config
+
+        Should use the default group
+        """
+    groups = {
+        "default": {"repos": ["foo"]},
+    }
+    create_manifest(tmp_path, repos=["foo", "outside"], groups=groups)
+    workspace = create_workspace(tmp_path)
+    args = new_args()
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo"]
+
+
+def test_no_args_workspace_configured_with_all_repos(tmp_path: Path) -> None:
+    """ Scenario:
+        * Nothing passed on the command line
+        * A default group in the manifest containing foo
+        * A repo named 'outside' in the manifest - not in any group
+        * Workspace configured with clone_all_repos: True
+
+        Should return everything
+        """
+    groups = {
+        "default": {"repos": ["foo"]},
+    }
+    create_manifest(tmp_path, repos=["foo", "outside"], groups=groups)
+    workspace = create_workspace(tmp_path, clone_all_repos=True)
+    args = new_args()
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo", "outside"]
+
+
+def test_no_args_workspace_configured_with_some_groups(tmp_path: Path) -> None:
+    """ Scenario:
+        * Nothing passed on the command line
+        * A group named 'group1' in the manifest containing foo
+        * A group named 'group2' in the manifest containing bar
+        * Workspace configured with repo_groups=[group1]
+
+        Should return foo from group1
+        """
+    groups = {
+        "group1": {"repos": ["foo"]},
+        "group2": {"repos": ["bar"]},
+    }
+    create_manifest(tmp_path, repos=["foo", "bar"], groups=groups)
+    workspace = create_workspace(tmp_path, repo_groups=["group1"])
+    args = new_args()
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo"]
+
+
+def test_groups_requested(tmp_path: Path) -> None:
+    """ Scenario:
+        * A group named 'group1' in the manifest containing foo
+        * A group named 'group2' in the manifest containing bar
+        * Workspace configured with repo_groups=[group1, group2]
+        * --group group1 used on the command line
+
+        Should return repos from group1
+        """
+    groups = {
+        "group1": {"repos": ["foo"]},
+        "group2": {"repos": ["bar"]},
+    }
+    create_manifest(tmp_path, repos=["foo", "bar"], groups=groups)
+    workspace = create_workspace(tmp_path, repo_groups=["group1"])
+    args = new_args(groups=["group1"])
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo"]
+
+
+def test_all_cloned_requested(tmp_path: Path) -> None:
+    """ Scenario:
+        * A group named 'group1' in the manifest containing foo and bar
+        * A repo named 'other' in the manifest
+        * Workspace configured with repo_groups=[group1]
+        * tmp_path / foo and tmp_path / other exists, but not tmp_path / bar
+        * --all-cloned used on the command line
+
+        Should return foo and other
+        """
+    groups = {
+        "group1": {"repos": ["foo", "bar"]},
+    }
+    create_manifest(tmp_path, repos=["foo", "bar", "other"], groups=groups)
+    workspace = create_workspace(tmp_path, repo_groups=["group1"])
+    args = new_args(all_cloned=True)
+
+    (tmp_path / "foo").makedirs_p()
+    (tmp_path / "other").makedirs_p()
+
+    actual = resolve_repos(workspace, args=args)
+    assert repo_names(actual) == ["foo", "other"]

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -48,14 +48,18 @@ class Workspace:
 
         self.config = WorkspaceConfig.from_file(self.cfg_path)
 
-    def get_repos(self) -> List[tsrc.Repo]:
-        all_repos = self.config.clone_all_repos
-        repo_groups = self.config.repo_groups
-        manifest = self.get_manifest()
-        if all_repos:
-            return manifest.get_repos(all_=True)
-        else:
-            return manifest.get_repos(groups=repo_groups)
+        # Note: at this point the repositories on which the user wishes to
+        # execute an action is unknown. This list will be set after processing
+        # the command line arguments (like `--group` or `--all-cloned`)
+        #
+        # In particular, you _cannot assume_ that every repo in this list was
+        # cloned - in other words, don't use `workspace.root_path / repo.dest`
+        # without checking that the path exists!
+        # This is because there can be a mismatch between the state of
+        # the workspace and the requested repos - for instance, the user could
+        # have configured a workspace with a `backend` group, but using
+        # a disjoint `front-end` group on the command line.
+        self.repos: List[tsrc.Repo] = []
 
     def get_manifest(self) -> tsrc.Manifest:
         return self.local_manifest.get_manifest()
@@ -67,7 +71,7 @@ class Workspace:
 
     def clone_missing(self) -> None:
         to_clone = []
-        for repo in self.get_repos():
+        for repo in self.repos:
             repo_path = self.root_path / repo.dest
             if not repo_path.exists():
                 to_clone.append(repo)
@@ -81,29 +85,30 @@ class Workspace:
     def set_remotes(self) -> None:
         if not self.config.singular_remote:
             remote_setter = RemoteSetter(self.root_path)
-            tsrc.executor.run_sequence(self.get_repos(), remote_setter)
+            tsrc.executor.run_sequence(self.repos, remote_setter)
 
     def perform_filesystem_operations(self) -> None:
-        repos = self.get_repos()
-        file_system_operator = FileSystemOperator(self.root_path, repos)
+        repos = self.repos
+        operator = FileSystemOperator(self.root_path, repos)
         manifest = self.local_manifest.get_manifest()
         operations = manifest.file_system_operations
         known_repos = [x.dest for x in repos]
         operations = [x for x in operations if x.repo in known_repos]  # type: ignore
-        tsrc.executor.run_sequence(operations, file_system_operator)
+        tsrc.executor.run_sequence(operations, operator)
 
     def sync(self, *, force: bool = False) -> None:
         syncer = Syncer(
             self.root_path, force=force, remote_name=self.config.singular_remote
         )
+        repos = self.repos
         try:
-            tsrc.executor.run_sequence(self.get_repos(), syncer)
+            tsrc.executor.run_sequence(repos, syncer)
         finally:
             syncer.display_bad_branches()
 
     def enumerate_repos(self) -> Iterable[Tuple[int, tsrc.Repo, Path]]:
         """ Yield (index, repo, full_path) for all the repos """
-        for i, repo in enumerate(self.get_repos()):
+        for i, repo in enumerate(self.repos):
             full_path = self.root_path / repo.dest
             yield (i, repo, full_path)
 

--- a/tsrc/workspace/remote_setter.py
+++ b/tsrc/workspace/remote_setter.py
@@ -49,7 +49,7 @@ class RemoteSetter(tsrc.executor.Task[tsrc.Repo]):
         # fmt: off
         ui.info_3(repo.dest + ":", "Update remote", ui.reset,
                   ui.bold, remote.name, ui.reset,
-                  "to new url:", ui.brown, "(", remote.url, ")")
+                  "to new url:", ui.brown, f"({remote.url})")
         # fmt: on
         tsrc.git.run(full_path, "remote", "set-url", remote.name, remote.url)
 
@@ -58,6 +58,6 @@ class RemoteSetter(tsrc.executor.Task[tsrc.Repo]):
         # fmt: off
         ui.info_3(repo.dest + ":", "Add remote",
                   ui.bold, remote.name, ui.reset,
-                  ui.brown, "(", remote.url, ")")
+                  ui.brown, f"({remote.url})")
         # fmt: on
         tsrc.git.run(full_path, "remote", "add", remote.name, remote.url)


### PR DESCRIPTION
* log, status, sync all have a --group option now

* foreach action now behaves like the rest :)

* --groups-from-config option is gone, since this is now the default behavior

* you can use --all-cloned to try and run the command on every cloned repo

* there is no way to run `log, status, sync` on all repos on the manifest without editing the workspace config first - I think this is OK

* getting the list of repos to use is now the responsibility of tsrc.cli, not the Workspace class