### PR TITLE
Add symlink support

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -8,6 +8,7 @@ Dimitri Merejkowsky
 Théo Delrieu
 Jakob Heuser
 Tronje Krabbe
+Matthew Lovell
 
 
 If you make a contribution, feel free to make a pull request to add your name

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -24,12 +24,13 @@ Each repository is also a dictionary, containing:
 * `tag` (optional):
     * When running `tsrc init`: Project will be cloned at the provided tag.
     * When running `tsrc sync`:  If the project is clean, project will be reset
-        to the given tag, else a warning message will be printed.
+	to the given tag, else a warning message will be printed.
 * `sha1` (optional):
     * When running `tsrc init`: Project will be cloned, and then reset to the given sha1.
     * When running `tsrc sync`:  If the project is clean, project will be reset
-        to the given sha1, else a warning message will be printed.
+	to the given sha1, else a warning message will be printed.
 * `copy` (optional): A list of dictionaries with `file` and `dest` keys.
+* `symlink` (optional): A list of dictionaries with `source` and `target` keys.
 
 Here's a full example:
 
@@ -41,9 +42,9 @@ repos:
 
   - remotes:
       - name: origin
-        url: git@gitlab.local:proj1/bar
+	url: git@gitlab.local:proj1/bar
       - name: upstream
-        url: git@github.com:user/bar
+	url: git@github.com:user/bar
     dest: bar
     branch: master
     sha1: ad2b68539c78e749a372414165acdf2a1bb68203
@@ -53,8 +54,11 @@ repos:
     tag: v0.1
     copy:
       - file: top.cmake
-        dest: CMakeLists.txt
+	dest: CMakeLists.txt
       - file: .clangformat
+    symlink:
+      - source: app/some_file
+	target: ../foo/some_file
 ```
 
 In this example:
@@ -63,10 +67,14 @@ In this example:
 * Then, `proj1/bar` will be cloned into `<workspace>/bar` using the `master` branch, and reset to `ad2b68539c78e749a372414165acdf2a1bb68203`.
 * Finally:
     * `proj1/app` will be cloned into `<workspace>/app` using the `v0.1` tag,
-    * `top.cmake` will be copied from `proj1/app/top.cmake` to `<workspace>/CMakeLists.txt`, and
-    * `.clang-format` will be copied from `proj1/app/` to `<workspace>/`.
+    * `top.cmake` will be copied from `proj1/app/top.cmake` to `<workspace>/CMakeLists.txt`,
+    * `.clang-format` will be copied from `proj1/app/` to `<workspace>/`, and
+    * a symlink is created from `<workspace>/app/some_file` to `<workspace>/foo/some_file`.
 
 Note that `copy` only works with files, not directories.
+
+The source and target paths for symbolic links are both relative to the top-level `<workspace>`.
+Multiple symlinks can be specified; each must specify a source and target.
 
 ## groups
 

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -69,7 +69,7 @@ In this example:
     * `proj1/app` will be cloned into `<workspace>/app` using the `v0.1` tag,
     * `top.cmake` will be copied from `proj1/app/top.cmake` to `<workspace>/CMakeLists.txt`,
     * `.clang-format` will be copied from `proj1/app/` to `<workspace>/`, and
-    * a symlink is created from `<workspace>/app/some_file` to `<workspace>/foo/some_file`.
+    * a symlink will be created from `<workspace>/app/some_file` to `<workspace>/foo/some_file`.
 
 Note that `copy` only works with files, not directories.
 

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -58,7 +58,7 @@ repos:
       - file: .clangformat
     symlink:
       - source: app/some_file
-	target: ../foo/some_file
+        target: ../foo/some_file
 ```
 
 In this example:

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -42,9 +42,9 @@ repos:
 
   - remotes:
       - name: origin
-	url: git@gitlab.local:proj1/bar
+        url: git@gitlab.local:proj1/bar
       - name: upstream
-	url: git@github.com:user/bar
+        url: git@github.com:user/bar
     dest: bar
     branch: master
     sha1: ad2b68539c78e749a372414165acdf2a1bb68203
@@ -54,7 +54,7 @@ repos:
     tag: v0.1
     copy:
       - file: top.cmake
-	dest: CMakeLists.txt
+        dest: CMakeLists.txt
       - file: .clangformat
     symlink:
       - source: app/some_file

--- a/docs/ref/formats.md
+++ b/docs/ref/formats.md
@@ -76,6 +76,15 @@ Note that `copy` only works with files, not directories.
 The source and target paths for symbolic links are both relative to the top-level `<workspace>`.
 Multiple symlinks can be specified; each must specify a source and target.
 
+Symlink creation is supported on all operating systems, but creation of NTFS symlinks on
+Windows requires that the current user have appropriate security policy permission
+(SeCreateSymbolicLinkPrivilege).  By default, only administrators have that privilege set,
+although newer versions of Windows 10 support a Developer Mode that permits unprivileged
+accounts to create symlinks.  Note that Cygwin running on Windows defaults to creating
+links via Windows shortcuts, which do *not* require any special privileges.
+(Cygwin's symlink behavior can be user controlled with the `winsymlinks` setting
+in the `CYGWIN` environment variable.)
+
 ## groups
 
 The `groups` section lists the groups by name. Each group should have a `repos` field

--- a/tsrc/__init__.py
+++ b/tsrc/__init__.py
@@ -7,7 +7,7 @@ from .errors import Error, InvalidConfig  # noqa
 from .executor import Task, run_sequence, ExecutorFailed  # noqa
 from .groups import GroupList, Group  # noqa
 from .groups import GroupNotFound, UnknownElement as UnknownGroupElement  # noqa
-from .repo import Repo, Remote, Copy  # noqa
+from .repo import Repo, Remote, Copy, Link  # noqa
 from .manifest import Manifest  # noqa
 from .manifest import load as load_manifest  # noqa
 from .workspace import Workspace  # noqa

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -75,9 +75,9 @@ class Manifest:
             return
         to_link = repo_config["symlink"]
         for item in to_link:
-            src = item["source"]
-            tgt = item.get("target", src)
-            link = tsrc.Link(src, tgt)
+            source = item["source"]
+            target = item["target"]
+            link = tsrc.Link(source, target)
             self.symlinks.append(link)
 
     def _handle_groups(self, groups_config: Any) -> None:

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -18,6 +18,19 @@ class Copy:
 
 
 @attr.s(frozen=True)
+class Link:
+    src = attr.ib()  # type: str
+    tgt = attr.ib()  # type: str
+
+
+@attr.s(frozen=True)
+class CopyDir:
+    repo = attr.ib()  # type: str
+    src = attr.ib()  # type: str
+    dest = attr.ib()  # type: str
+
+
+@attr.s(frozen=True)
 class Repo:
     dest = attr.ib()  # type: str
     remotes = attr.ib()  # type: List[Remote]

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -19,15 +19,8 @@ class Copy:
 
 @attr.s(frozen=True)
 class Link:
-    src = attr.ib()  # type: str
-    tgt = attr.ib()  # type: str
-
-
-@attr.s(frozen=True)
-class CopyDir:
-    repo = attr.ib()  # type: str
-    src = attr.ib()  # type: str
-    dest = attr.ib()  # type: str
+    source = attr.ib()  # type: str
+    target = attr.ib()  # type: str
 
 
 @attr.s(frozen=True)

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -28,6 +28,9 @@ repos:
       - file: top.cmake
         dest: CMakeLists.txt
       - file: .clang-format
+    symlink:
+      - source: master/some_file
+        target: ../foo/some_file
 """
     manifest = tsrc.Manifest()
     parsed = ruamel.yaml.safe_load(contents)
@@ -58,6 +61,9 @@ repos:
     assert manifest.copyfiles == [
         tsrc.Copy("master", "top.cmake", "CMakeLists.txt"),
         tsrc.Copy("master", ".clang-format", ".clang-format"),
+    ]
+    assert manifest.symlinks == [
+        tsrc.Link("master/some_file", "../foo/some_file"),
     ]
 
 

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -13,6 +13,7 @@ import tsrc.git
 
 from .cloner import Cloner
 from .copier import FileCopier
+from .linker import FileLinker
 from .syncer import Syncer
 from .remote_setter import RemoteSetter
 from .local_manifest import LocalManifest
@@ -86,9 +87,12 @@ class Workspace:
     def copy_files(self) -> None:
         repos = self.get_repos()
         file_copier = FileCopier(self.root_path, repos)
+        file_linker = FileLinker(self.root_path, repos)
         manifest = self.local_manifest.get_manifest()
         copyfiles = manifest.copyfiles
         tsrc.executor.run_sequence(copyfiles, file_copier)
+        symlinks = manifest.symlinks
+        tsrc.executor.run_sequence(symlinks, file_linker)
 
     def sync(self, *, force: bool = False) -> None:
         syncer = Syncer(

--- a/tsrc/workspace/linker.py
+++ b/tsrc/workspace/linker.py
@@ -20,18 +20,18 @@ class FileLinker(tsrc.executor.Task[tsrc.Link]):
         ui.error("Failed to create the following symlinks:")
 
     def display_item(self, item: tsrc.Link) -> str:
-        return f"{item.src} linking to {item.tgt}"
+        return f"{item.source} linking to {item.target}"
 
     def process(self, index: int, count: int, item: tsrc.Link) -> None:
-        ui.info_count(index, count, "Linking", item.src, "->", item.tgt)
+        ui.info_count(index, count, "Linking", item.source, "->", item.target)
         # Both paths are assumed to already be workspace-relative
-        src_path = Path(item.src)
-        tgt_path = Path(item.tgt)
-        if src_path.isabs():
-            ui.error("Absolute path specified as symlink name:", src_path)
+        source_path = Path(item.source)
+        target_path = Path(item.target)
+        if source_path.isabs():
+            ui.error("Absolute path specified as symlink name:", source_path)
             return
         try:
-            full_src = self.workspace_path / item.src
-            os.symlink(tgt_path, full_src, tgt_path.isdir())
+            full_source = self.workspace_path / item.source
+            os.symlink(target_path, full_source, target_path.isdir())
         except Exception as e:
             raise tsrc.Error(str(e))

--- a/tsrc/workspace/linker.py
+++ b/tsrc/workspace/linker.py
@@ -1,0 +1,37 @@
+from typing import List
+
+import cli_ui as ui
+from path import Path
+
+import tsrc
+import tsrc.executor
+import os
+
+
+class FileLinker(tsrc.executor.Task[tsrc.Link]):
+    def __init__(self, workspace_path: Path, repos: List[tsrc.Repo]) -> None:
+        self.workspace_path = workspace_path
+        self.repos = repos
+
+    def on_start(self, *, num_items: int) -> None:
+        ui.info_2("Creating symlinks")
+
+    def on_failure(self, *, num_errors: int) -> None:
+        ui.error("Failed to create the following symlinks:")
+
+    def display_item(self, item: tsrc.Link) -> str:
+        return f"{item.src} linking to {item.tgt}"
+
+    def process(self, index: int, count: int, item: tsrc.Link) -> None:
+        ui.info_count(index, count, "Linking", item.src, "->", item.tgt)
+        # Both paths are assumed to already be workspace-relative
+        src_path = Path(item.src)
+        tgt_path = Path(item.tgt)
+        if src_path.isabs():
+            ui.error("Absolute path specified as symlink name:", src_path)
+            return
+        try:
+            full_src = self.workspace_path / item.src
+            os.symlink(tgt_path, full_src, tgt_path.isdir())
+        except Exception as e:
+            raise tsrc.Error(str(e))


### PR DESCRIPTION
This is a re-packaging of earlier work into a single commit to
make for a simpler review.

 - manifest.py schema validation updated to support a "symlink"
   section as a peer to "copy".

 - Each desired symlink must specify both a source and target,
   taken as workspace-relative paths.

Example manifest.yml file in formats.md updated.  Also updated
test_manifest.py to exercise updated manifest parsing.


Here is the example manifest.yml file that was used for testing during development:
```
repos:
  - url: git@dh-vlsi-cm01.colo.company.com:vlsi/dre-tb
    dest: dre-tb
    sha1: 908fefb

  - url: git@dh-vlsi-cm01.colo.company.com:vlsi/tbng
    dest: dre-tb/tbng
    
  - url: git@dh-vlsi-cm01.colo.company.com:vlsi/sidewinder-layout
    dest: layout

  - url: git@dh-vlsi-cm01.colo.company.com:vlsi/tick-rtl
    dest: design
    branch: fpga_42
    symlink:
      - source: dre-tb/design
        target: ../design
      - source: dre-tb/dummy_link
        target: ../layout
    copy:
      - file: pcie/rtl/build.cfg
        dest: matt_dummy_copy_file
```

Excerpt from running tsrc init:
```
Receiving objects: 100% (12093/12093), 22.81 MiB | 14.46 MiB/s, done.
Resolving deltas: 100% (8438/8438), done.
Updating files: 100% (1126/1126), done.
=> Configuring remotes
=> Copying files
* (1/1) pcie/rtl/build.cfg -> matt_dummy_copy_file
=> Creating symlinks
* (1/2) Linking dre-tb/design -> ../design
* (2/2) Linking dre-tb/dummy_link -> ../layout
=> Workspace initialized
=> Configuration written in /home/mlovell/projects/tsrc_exp/.tsrc/config.yml
```

