### PR TITLE
Resolve symlink path and unit test woes under (native) Windows

### DIFF
--- a/tsrc/file_system.py
+++ b/tsrc/file_system.py
@@ -21,7 +21,9 @@ def safe_link(*, source: Path, target: Path) -> None:
     make_link = check_link(source=source, target=target)
     if make_link:
         ui.info_3("Creating link", source, "->", target)
-        os.symlink(target.normpath(), source.normpath(), target_is_directory=target.isdir())
+        os.symlink(
+            target.normpath(), source.normpath(), target_is_directory=target.isdir()
+        )
 
 
 def check_link(*, source: Path, target: Path) -> bool:

--- a/tsrc/file_system.py
+++ b/tsrc/file_system.py
@@ -21,7 +21,7 @@ def safe_link(*, source: Path, target: Path) -> None:
     make_link = check_link(source=source, target=target)
     if make_link:
         ui.info_3("Creating link", source, "->", target)
-        os.symlink(target, source, target_is_directory=target.isdir())
+        os.symlink(target.normpath(), source.normpath(), target_is_directory=target.isdir())
 
 
 def check_link(*, source: Path, target: Path) -> bool:
@@ -33,7 +33,7 @@ def check_link(*, source: Path, target: Path) -> bool:
         if source.exists():
             # symlink exists and points to some target
             current_target = source.readlink()
-            if current_target == target:
+            if current_target.realpath() == target.realpath():
                 ui.info_3("Leaving existing link")
                 return False
             else:

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -37,7 +37,7 @@ class Copy(FileSystemOperation):
         src_path.copy(dest_path)
 
     def __str__(self) -> str:
-        return f"copy from '{self.repo}/{self.src}' to '{self.dest}"
+        return f"copy from '{self.repo}/{self.src}' to '{self.dest}'"
 
 
 @attr.s(frozen=True)
@@ -52,7 +52,7 @@ class Link(FileSystemOperation):
         tsrc.file_system.safe_link(source=source, target=target)
 
     def __str__(self) -> str:
-        return f"link from '{self.source}' to '{self.target}"
+        return f"link from '{self.source}' to '{self.target}'"
 
 
 @attr.s(frozen=True)

--- a/tsrc/test/cli/test_init.py
+++ b/tsrc/test/cli/test_init.py
@@ -7,6 +7,7 @@ from tsrc.test.helpers.cli import CLI
 from tsrc.test.helpers.git_server import GitServer
 
 from path import Path
+import os
 
 
 def repo_exists(workspace_path: Path, repo: str) -> bool:
@@ -122,7 +123,7 @@ def test_create_symlink(
 
     actual_link = workspace_path / "foo.link"
     assert actual_link.exists()
-    assert actual_link.readlink() == "foo/foo.txt"
+    assert actual_link.readlink() == os.path.normpath("foo/foo.txt")
 
 
 def test_uses_correct_branch_for_repo(

--- a/tsrc/test/cli/test_sync.py
+++ b/tsrc/test/cli/test_sync.py
@@ -266,7 +266,7 @@ def test_update_symlink(
 
     actual_link = workspace_path / "foo.link"
     assert actual_link.exists()
-    assert actual_link.readlink() == "foo/bar.txt"
+    assert actual_link.readlink() == os.path.normpath("foo/bar.txt")
 
 
 def test_changing_branch(

--- a/tsrc/test/test_file_system.py
+++ b/tsrc/test/test_file_system.py
@@ -9,9 +9,8 @@ def test_can_create_symlink_when_source_does_not_exist(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.touch()
     tsrc.file_system.safe_link(source=source, target=target)
-
     assert source.exists()
-    assert source.readlink() == target
+    assert source.realpath() == target.realpath()
 
 
 def test_can_create_symlink_pointing_to_diretory(tmp_path: Path) -> None:
@@ -21,7 +20,7 @@ def test_can_create_symlink_pointing_to_diretory(tmp_path: Path) -> None:
     tsrc.file_system.safe_link(source=source, target=target)
 
     assert source.exists()
-    assert source.readlink() == target
+    assert source.realpath() == target.realpath()
 
 
 def test_cannot_create_symlink_when_source_is_a_file(tmp_path: Path) -> None:
@@ -43,7 +42,7 @@ def test_can_update_broken_symlink(tmp_path: Path) -> None:
     tsrc.file_system.safe_link(source=source, target=new_target)
 
     assert source.exists()
-    assert source.readlink() == new_target
+    assert source.realpath() == new_target.realpath()
 
 
 def test_can_update_existing_symlink(tmp_path: Path) -> None:
@@ -57,7 +56,7 @@ def test_can_update_existing_symlink(tmp_path: Path) -> None:
 
     new_target.touch()
     assert source.exists()
-    assert source.readlink() == new_target
+    assert source.realpath() == new_target.realpath()
 
 
 def test_do_nothing_if_symlink_has_the_correct_target(tmp_path: Path) -> None:
@@ -69,4 +68,4 @@ def test_do_nothing_if_symlink_has_the_correct_target(tmp_path: Path) -> None:
     tsrc.file_system.safe_link(source=source, target=target)
 
     assert source.exists()
-    assert source.readlink() == target
+    assert source.realpath() == target.realpath()


### PR DESCRIPTION
I think these changes should resolve the test woes.  They also ensure that normpath() gets called for the os.symlink() arguments.
