### PR TITLE
Add helpful docstrings and comments

### DIFF
--- a/tsrc/__init__.py
+++ b/tsrc/__init__.py
@@ -1,6 +1,7 @@
-""" Common tools """
-
 __version__ = "2.2.0"
+
+# Re-exports objects from underlying packages (so that we can use
+# tsrc.Workspace instead of tsrc.workspace.Workspace).
 
 from .config import Config, parse_config  # noqa
 from .errors import Error, InvalidConfig  # noqa

--- a/tsrc/__init__.py
+++ b/tsrc/__init__.py
@@ -5,9 +5,10 @@ __version__ = "2.2.0"
 from .config import Config, parse_config  # noqa
 from .errors import Error, InvalidConfig  # noqa
 from .executor import Task, run_sequence, ExecutorFailed  # noqa
+from .file_system import Copy, Link, FileSystemOperation  # noqa
 from .groups import GroupList, Group  # noqa
 from .groups import GroupNotFound, UnknownElement as UnknownGroupElement  # noqa
-from .repo import Repo, Remote, Copy, Link, FileSystemOperation  # noqa
+from .repo import Repo, Remote  # noqa
 from .manifest import Manifest  # noqa
 from .manifest import load as load_manifest  # noqa
 from .workspace import Workspace  # noqa

--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -1,4 +1,4 @@
-""" Common tools for tsrc commands """
+""" Common tools for tsrc commands. """
 
 import functools
 from typing import Any, Callable, List, Optional
@@ -25,6 +25,9 @@ def composed(*decorators: Callable) -> Callable:
     return inner
 
 
+# Define a common set of command line options.
+# For instance, almost every command has a
+# `-w,--workspace` option, which is defined here.
 workspace_arg = arg(
     "-w",
     "--workspace",
@@ -44,10 +47,20 @@ all_cloned_arg = arg(
 
 
 def repos_arg(f: Callable) -> Callable:
+    """
+    Define a set of command line options to select a group of
+    repos, like `--group` and `--all-cloned`.
+    """
     return composed(workspace_arg, groups_arg, all_cloned_arg)(f)  # type: ignore
 
 
 def workspace_action(f: Callable) -> Callable:
+    """
+    Take a function that has a `workspace_path` parameter and return
+    a function that takes a `Workspace` instance instead.
+
+    """
+
     @functools.wraps(f)
     def res(*args: Any, workspace_path: Optional[Path] = None, **kwargs: Any) -> Any:
         if not workspace_path:
@@ -59,6 +72,14 @@ def workspace_action(f: Callable) -> Callable:
 
 
 def repos_action(f: Callable) -> Callable:
+    """
+    Take a function that has all the parameters required by the
+    `repos_arg` group of command line options, and return a function
+    that takes a `Workspace` instance the `repos` attribute correctly
+    set.
+
+    """
+
     @functools.wraps(f)
     def res(
         *args: Any,
@@ -77,10 +98,10 @@ def repos_action(f: Callable) -> Callable:
 
 
 def find_workspace_path() -> Path:
-    """ Look for a workspace root somewhere in the upper directories
-    hierarchy
-
     """
+    Find the workspace path when not specified on the command line.
+    """
+    # Walk up the file system hierarchy until a `.tsrc` directory is found
     head = os.getcwd()
     tail = "a truthy string"
     while tail:
@@ -94,6 +115,12 @@ def find_workspace_path() -> Path:
 
 
 def get_workspace(workspace_path: Optional[Path]) -> tsrc.Workspace:
+    """
+    Return a workspace instance after having parsed command line
+    arguments.
+
+    Uses the value of the `-w, --workspace` option.
+    """
     if not workspace_path:
         workspace_path = find_workspace_path()
     return tsrc.Workspace(workspace_path)
@@ -102,6 +129,13 @@ def get_workspace(workspace_path: Optional[Path]) -> tsrc.Workspace:
 def get_workspace_with_repos(
     workspace_path: Path, groups: Optional[List[str]], all_cloned: bool
 ) -> tsrc.Workspace:
+    """
+    Return a workspace instance and its repos after having parsed the
+    command line.
+
+    Uses the value of the `-w, --workspace` option first, then the values
+    of the  `--groups` and `--all-cloned` options.
+    """
     workspace = get_workspace(workspace_path)
     workspace.repos = resolve_repos(workspace, groups, all_cloned)
     return workspace
@@ -110,7 +144,7 @@ def get_workspace_with_repos(
 def resolve_repos(
     workspace: Workspace, groups: Optional[List[str]], all_cloned: bool
 ) -> List[tsrc.Repo]:
-    """"
+    """
     Given a workspace with its config and its local manifest,
     and a collection of parsed command  line arguments,
     return the list of repositories to operate on.
@@ -125,13 +159,17 @@ def resolve_repos(
         return [repo for repo in repos if (workspace.root_path / repo.dest).exists()]
 
     # At this point, nothing was requested on the command line, time to
-    # use the workspace configuration
+    # use the workspace configuration:
     return repos_from_config(manifest, workspace.config)
 
 
 def repos_from_config(
     manifest: Manifest, workspace_config: WorkspaceConfig
 ) -> List[tsrc.Repo]:
+    """
+    Given a workspace config, returns a list of repos.
+
+    """
     clone_all_repos = workspace_config.clone_all_repos
     repo_groups = workspace_config.repo_groups
 

--- a/tsrc/cli/apply_manifest.py
+++ b/tsrc/cli/apply_manifest.py
@@ -1,4 +1,4 @@
-""" Entry point for `tsrc apply-manifest` """
+""" Entry point for `tsrc apply-manifest`. """
 
 from typing import Any
 
@@ -8,11 +8,7 @@ from path import Path
 import cli_ui as ui
 
 import tsrc.manifest
-from tsrc.cli import (
-    workspace_arg,
-    workspace_action,
-    repos_from_config,
-)
+from tsrc.cli import workspace_arg, workspace_action, repos_from_config
 
 
 @workspace_arg  # type: ignore

--- a/tsrc/cli/foreach.py
+++ b/tsrc/cli/foreach.py
@@ -1,4 +1,4 @@
-""" Entry point for tsrc foreach """
+""" Entry point for `tsrc foreach`. """
 
 from typing import Any, List, Union
 from argh import arg
@@ -10,10 +10,7 @@ from path import Path
 import cli_ui as ui
 
 import tsrc
-from tsrc.cli import (
-    repos_arg,
-    repos_action,
-)
+from tsrc.cli import repos_arg, repos_action
 
 EPILOG = textwrap.dedent(
     """\
@@ -39,6 +36,10 @@ class CouldNotStartProcess(tsrc.Error):
 
 
 class CmdRunner(tsrc.Task[tsrc.Repo]):
+    """
+    Implements a Task that runs the same command on several repositories.
+    """
+
     def __init__(
         self,
         workspace_path: Path,
@@ -90,7 +91,9 @@ def die(message: str) -> None:
 @repos_arg
 @repos_action
 @arg("cmd", help="command to run", nargs="*", default=None)  # type: ignore
-@arg("-c", help="use a shell to run the command", dest="shell", default=False)  # type: ignore
+@arg(  # type: ignore
+    "-c", help="use a shell to run the command", dest="shell", default=False
+)
 def foreach(workspace: tsrc.Workspace, *args: Any, **kwargs: Any) -> None:
     cmd: List[str] = args  # type: ignore
     shell: bool = kwargs["shell"]
@@ -100,8 +103,8 @@ def foreach(workspace: tsrc.Workspace, *args: Any, **kwargs: Any) -> None:
     #  and
     #  $ tsrc foreach -- some-cmd --some-opts
     #
-    # Due to argparse limitations, cmd will always be a list,
-    # but we need a *string* when using 'shell=True'
+    # Due to argparse limitations, `cmd` will always be a list,
+    # but we need a *string* when using 'shell=True'.
     #
     # So transform use the value from `cmd` and `shell` to build:
     # * `subprocess_cmd`, suitable as argument to pass to subprocess.run()

--- a/tsrc/cli/init.py
+++ b/tsrc/cli/init.py
@@ -1,4 +1,4 @@
-""" Entry point for `tsrc init` """
+""" Entry point for `tsrc init`. """
 from typing import List, Optional
 import os
 

--- a/tsrc/cli/log.py
+++ b/tsrc/cli/log.py
@@ -1,4 +1,4 @@
-""" Entry point for tsrc log """
+""" Entry point for `tsrc log`. """
 
 from typing import Any
 
@@ -18,7 +18,7 @@ from tsrc.cli import (
 @arg("--from", dest="from", metavar="FROM", help="from ref")  # type: ignore
 @arg("--to", help="to ref")  # type: ignore
 def log(workspace: tsrc.Workspace, **kwargs: Any) -> None:
-    """ show a combine git log for several repositories """
+    """ show a combined git log for several repositories """
     from_: str = kwargs["from"]
     to: str = kwargs["to"] or "HEAD"
 

--- a/tsrc/cli/main.py
+++ b/tsrc/cli/main.py
@@ -1,4 +1,4 @@
-""" Main tsrc entry point """
+""" Main tsrc entry point. """
 
 import argparse
 import argh
@@ -25,7 +25,7 @@ MainFunc = Callable[..., None]
 
 
 def main_wrapper(main_func: MainFunc) -> MainFunc:
-    """ Wraps main() entry point to better deal with errors """
+    """ Wraps main() entry point to better deal with errors. """
 
     @functools.wraps(main_func)
     def wrapped(args: ArgsList = None) -> None:
@@ -33,11 +33,10 @@ def main_wrapper(main_func: MainFunc) -> MainFunc:
         try:
             main_func(args=args)
         except tsrc.Error as e:
-            # "expected" failure, display it and exit
-            # note: we allow tsrc.Error instances to have an
-            # empty message. In that case, do not print
-            # anything and assume relevant info has
-            # already been printed
+            # "expected" failure, display it and exit note: we allow
+            # tsrc.Error instances to have an empty message. In that
+            # case, do not print anything and assume relevant info has
+            # already been printed.
             if e.message:
                 ui.error(e.message)
             sys.exit(1)
@@ -49,6 +48,10 @@ def main_wrapper(main_func: MainFunc) -> MainFunc:
 
 
 def setup_ui(args: argparse.Namespace) -> None:
+    """ Configure the cli_ui package using options
+    set on the command line and environment variables.
+
+    """
     verbose = False
     if os.environ.get("VERBOSE"):
         verbose = True
@@ -57,12 +60,17 @@ def setup_ui(args: argparse.Namespace) -> None:
     ui.setup(verbose=verbose, quiet=args.quiet, color=args.color)
 
 
-def testable_main(args: ArgsList) -> None:
+@main_wrapper
+def main(args: ArgsList = None) -> None:
+    """ Main entry point. """
     main_impl(args=args)
 
 
-@main_wrapper
-def main(args: ArgsList = None) -> None:
+def testable_main(args: ArgsList) -> None:
+    """ Same behavior as the main entrypoint, except we never
+    hide backtraces when an exception is raised.
+
+    """
     main_impl(args=args)
 
 

--- a/tsrc/cli/status.py
+++ b/tsrc/cli/status.py
@@ -18,18 +18,24 @@ from tsrc.cli import (
 
 
 class ManifestStatus:
+    """ Represent the status of a repo w.r.t the manifest. """
+
     def __init__(self, repo: tsrc.Repo, *, manifest: tsrc.Manifest):
         self.repo = repo
         self.manifest = manifest
         self.incorrect_branch = None  # type: Optional[Tuple[str,str]]
 
     def update(self, git_status: tsrc.git.Status) -> None:
+        """ Set self.incorrect_branch if the local git status
+        does not match the branch set in the manifest.
+        """
         expected_branch = self.repo.branch
         actual_branch = git_status.branch
         if actual_branch and actual_branch != expected_branch:
             self.incorrect_branch = (actual_branch, expected_branch)
 
     def describe(self) -> List[ui.Token]:
+        """ Return a list of tokens suitable for ui.info()`. """
         res = []  # type: List[ui.Token]
         incorrect_branch = self.incorrect_branch
         if incorrect_branch:
@@ -39,6 +45,8 @@ class ManifestStatus:
 
 
 class Status:
+    """ Wrapper class for both ManifestStatus and GitStatus"""
+
     def __init__(self, *, git: tsrc.git.Status, manifest: ManifestStatus):
         self.git = git
         self.manifest = manifest
@@ -49,7 +57,7 @@ CollectedStatuses = Dict[str, StatusOrError]
 
 
 def describe_status(status: StatusOrError) -> List[ui.Token]:
-    """ Returns a list of tokens suitable for ui.info() """
+    """ Return a list of tokens suitable for ui.info(). """
     if isinstance(status, tsrc.errors.MissingRepo):
         return [ui.red, "error: missing repo"]
     if isinstance(status, Exception):
@@ -65,6 +73,10 @@ def erase_last_line() -> None:
 
 
 class StatusCollector(tsrc.Task[tsrc.Repo]):
+    """ Implement a Task to collect local git status and
+    stats w.r.t the manifest for each repo.
+    """
+
     def __init__(self, workspace: tsrc.Workspace) -> None:
         self.workspace = workspace
         self.manifest = workspace.get_manifest()

--- a/tsrc/cli/sync.py
+++ b/tsrc/cli/sync.py
@@ -1,4 +1,4 @@
-""" Entry point for tsrc sync """
+""" Entry point for `tsrc sync` """
 
 from typing import List, Optional
 import cli_ui as ui

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -2,7 +2,7 @@
 
 from path import Path
 import ruamel.yaml
-import schema
+from schema import Schema, SchemaError
 from typing import Any, Dict, NewType, Optional
 
 import tsrc
@@ -10,9 +10,7 @@ import tsrc
 Config = NewType("Config", Dict[str, Any])
 
 
-def parse_config(
-    file_path: Path, config_schema: Optional[schema.Schema] = None
-) -> Config:
+def parse_config(file_path: Path, config_schema: Optional[Schema] = None) -> Config:
     try:
         contents = file_path.read_text()
     except OSError as os_error:
@@ -25,6 +23,6 @@ def parse_config(
     if config_schema:
         try:
             config_schema.validate(parsed)
-        except schema.SchemaError as schema_error:
+        except SchemaError as schema_error:
             raise tsrc.InvalidConfig(file_path, schema_error)
     return Config(parsed)

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -10,7 +10,7 @@ import tsrc
 Config = NewType("Config", Dict[str, Any])
 
 
-def parse_config(file_path: Path, config_schema: Optional[Schema] = None) -> Config:
+def parse_config(file_path: Path, schema: Optional[Schema] = None) -> Config:
     try:
         contents = file_path.read_text()
     except OSError as os_error:
@@ -20,9 +20,9 @@ def parse_config(file_path: Path, config_schema: Optional[Schema] = None) -> Con
         parsed = yaml.load(contents)
     except ruamel.yaml.error.YAMLError as yaml_error:
         raise tsrc.InvalidConfig(file_path, yaml_error)
-    if config_schema:
+    if schema:
         try:
-            config_schema.validate(parsed)
+            schema.validate(parsed)
         except SchemaError as schema_error:
             raise tsrc.InvalidConfig(file_path, schema_error)
     return Config(parsed)

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -3,14 +3,14 @@
 from path import Path
 import ruamel.yaml
 from schema import Schema, SchemaError
-from typing import Any, Dict, NewType, Optional
+from typing import Any, Dict, NewType
 
 import tsrc
 
 Config = NewType("Config", Dict[str, Any])
 
 
-def parse_config(file_path: Path, schema: Optional[Schema] = None) -> Config:
+def parse_config(file_path: Path, *, schema: Schema) -> Config:
     try:
         contents = file_path.read_text()
     except OSError as os_error:
@@ -20,9 +20,8 @@ def parse_config(file_path: Path, schema: Optional[Schema] = None) -> Config:
         parsed = yaml.load(contents)
     except ruamel.yaml.error.YAMLError as yaml_error:
         raise tsrc.InvalidConfig(file_path, yaml_error)
-    if schema:
-        try:
-            schema.validate(parsed)
-        except SchemaError as schema_error:
-            raise tsrc.InvalidConfig(file_path, schema_error)
+    try:
+        schema.validate(parsed)
+    except SchemaError as schema_error:
+        raise tsrc.InvalidConfig(file_path, schema_error)
     return Config(parsed)

--- a/tsrc/config.py
+++ b/tsrc/config.py
@@ -11,6 +11,11 @@ Config = NewType("Config", Dict[str, Any])
 
 
 def parse_config(file_path: Path, *, schema: Schema) -> Config:
+    """ Parse a config given a file path and a schema."""
+
+    # Note: we try and wrap any raised exception into a generic
+    # tsrc.InvalidConfig error, so that error messages always contains
+    # the path of the file that caused the error.
     try:
         contents = file_path.read_text()
     except OSError as os_error:

--- a/tsrc/errors.py
+++ b/tsrc/errors.py
@@ -7,7 +7,7 @@ DOC_URL = "https://TankerHQ.github.io/tsrc/ref/formats/"
 
 
 class Error(Exception):
-    """ Base class for our own errors
+    """ Base class for our own errors.
 
     """
 

--- a/tsrc/file_system.py
+++ b/tsrc/file_system.py
@@ -1,9 +1,51 @@
+import abc
 import os
 
+import attr
 import cli_ui as ui
 from path import Path
 
 import tsrc
+
+
+class FileSystemOperation(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def perform(self, workspace_path: Path) -> None:
+        pass
+
+    @abc.abstractmethod
+    def __str__(self) -> str:
+        pass
+
+
+@attr.s(frozen=True)
+class Copy(FileSystemOperation):
+    repo = attr.ib()  # type: str
+    src = attr.ib()  # type: str
+    dest = attr.ib()  # type: str
+
+    def perform(self, workspace_path: Path) -> None:
+        src_path = workspace_path / self.repo / self.src
+        dest_path = workspace_path / self.dest
+        src_path.copy(dest_path)
+
+    def __str__(self) -> str:
+        return f"copy from '{self.repo}/{self.src}' to '{self.dest}'"
+
+
+@attr.s(frozen=True)
+class Link(FileSystemOperation):
+    repo = attr.ib()  # type: str
+    source = attr.ib()  # type: str
+    target = attr.ib()  # type: str
+
+    def perform(self, workspace_path: Path) -> None:
+        source = workspace_path / self.source
+        target = Path(self.target)
+        safe_link(source=source, target=target)
+
+    def __str__(self) -> str:
+        return f"link from '{self.source}' to '{self.target}'"
 
 
 def safe_link(*, source: Path, target: Path) -> None:

--- a/tsrc/file_system.py
+++ b/tsrc/file_system.py
@@ -49,7 +49,7 @@ class Link(FileSystemOperation):
 
 
 def safe_link(*, source: Path, target: Path) -> None:
-    """ Safely create a link in 'source' pointing to 'target' """
+    """ Safely create a link in 'source' pointing to 'target'. """
     # Not: we need to call both islink() and exist() to safely ensure
     # that the link exists:
     #

--- a/tsrc/git.py
+++ b/tsrc/git.py
@@ -48,7 +48,16 @@ def assert_working_path(path: Path) -> None:
 
 
 class Status:
+    """ Represent a status of a git repo.
+
+    Usage:
+    >>> status = Status(repo_path)
+    >>> status.update()
+    """
+
     def __init__(self, working_path: Path) -> None:
+        # Note: at this point no information is known, and all
+        # attributes have their default value.
         self.empty = False
         self.working_path = working_path
         self.untracked = 0
@@ -63,6 +72,8 @@ class Status:
         self.sha1 = None  # type: Optional[str]
 
     def update(self) -> None:
+        # Try and gather as many information about the git repository as
+        # possible.
         try:
             self.update_sha1()
         except CommandError:
@@ -119,6 +130,7 @@ class Status:
                 self.dirty = True
 
     def describe(self) -> List[ui.Token]:
+        """ Return a list of tokens suitable for ui.info. """
         res = []  # type: List[ui.Token]
         if self.empty:
             return [ui.red, "empty"]
@@ -139,12 +151,19 @@ class Status:
 
     @staticmethod
     def commit_string(number: int) -> str:
+        """ Describe the number of commit with correct pluralization. """
+
         if number == 1:
             return "commit"
         else:
             return "commits"
 
     def describe_position(self) -> List[ui.Token]:
+        """ Return a status looking like `↑2↓1` if the branch
+        is 2 commits ahead and one commit behind its upstream,
+        as a list of tokens suitable for `ui.info()`.
+
+        """
         res = []  # type: List[ui.Token]
         if self.ahead != 0:
             n_commits = Status.commit_string(self.ahead)
@@ -157,6 +176,7 @@ class Status:
         return res
 
     def describe_dirty(self) -> List[ui.Token]:
+        """ Add the `(dirty)` colored string if the repo is dirty. """
         res = []  # type: List[ui.Token]
         if self.dirty:
             res += [ui.red, "(dirty)", ui.reset]
@@ -164,7 +184,7 @@ class Status:
 
 
 def run(working_path: Path, *cmd: str, check: bool = True) -> None:
-    """ Run git `cmd` in given `working_path`
+    """ Run git `cmd` in given `working_path`.
 
     Raise GitCommandError if return code is non-zero and `check` is True.
     """
@@ -179,11 +199,11 @@ def run(working_path: Path, *cmd: str, check: bool = True) -> None:
 
 
 def run_captured(working_path: Path, *cmd: str, check: bool = True) -> Tuple[int, str]:
-    """ Run git `cmd` in given `working_path`, capturing the output
+    """ Run git `cmd` in given `working_path`, capturing the output.
 
     Return a tuple (returncode, output).
 
-    Raise GitCommandError if return code is non-zero and check is True
+    Raise GitCommandError if return code is non-zero and check is True.
     """
     assert_working_path(working_path)
     git_cmd = list(cmd)

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -1,4 +1,4 @@
-""" manifests for tsrc """
+""" Manifest support. """
 
 # TODO: check for absolute paths in _handle_copies, _handle_links
 
@@ -17,6 +17,11 @@ class RepoNotFound(tsrc.Error):
 
 
 class Manifest:
+    """ Contains a list of `tsrc.Repo` instances, and optionally
+    a group list.
+
+    """
+
     def __init__(self) -> None:
         self._repos = []  # type: List[tsrc.Repo]
         self.group_list = None  # type:  Optional[tsrc.GroupList[str]]
@@ -155,6 +160,10 @@ def validate_repo(data: Any) -> None:
 
 
 def load(manifest_path: Path) -> Manifest:
+    """ Main entry point: return a manifest instance by parsing
+    a `manifest.yml` file.
+
+    """
     remote_git_server_schema = {"url": str}
     repo_schema = schema.Use(validate_repo)
     group_schema = {"repos": [str], schema.Optional("includes"): [str]}

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -168,7 +168,7 @@ def load(manifest_path: Path) -> Manifest:
             schema.Optional("groups"): {str: group_schema},
         }
     )
-    parsed = tsrc.parse_config(manifest_path, manifest_schema)
+    parsed = tsrc.parse_config(manifest_path, schema=manifest_schema)
     res = Manifest()
     res.apply_config(parsed)
     return res

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -1,12 +1,7 @@
 """ Repo objects """
 from typing import Optional, List  # noqa
 
-import abc
-
 import attr
-from path import Path
-
-import tsrc.file_system
 
 
 @attr.s(frozen=True)
@@ -28,43 +23,3 @@ class Repo:
 class Remote:
     name = attr.ib()  # type: str
     url = attr.ib()  # type: str
-
-
-class FileSystemOperation(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def perform(self, workspace_path: Path) -> None:
-        pass
-
-    @abc.abstractmethod
-    def __str__(self) -> str:
-        pass
-
-
-@attr.s(frozen=True)
-class Copy(FileSystemOperation):
-    repo = attr.ib()  # type: str
-    src = attr.ib()  # type: str
-    dest = attr.ib()  # type: str
-
-    def perform(self, workspace_path: Path) -> None:
-        src_path = workspace_path / self.repo / self.src
-        dest_path = workspace_path / self.dest
-        src_path.copy(dest_path)
-
-    def __str__(self) -> str:
-        return f"copy from '{self.repo}/{self.src}' to '{self.dest}'"
-
-
-@attr.s(frozen=True)
-class Link(FileSystemOperation):
-    repo = attr.ib()  # type: str
-    source = attr.ib()  # type: str
-    target = attr.ib()  # type: str
-
-    def perform(self, workspace_path: Path) -> None:
-        source = workspace_path / self.source
-        target = Path(self.target)
-        tsrc.file_system.safe_link(source=source, target=target)
-
-    def __str__(self) -> str:
-        return f"link from '{self.source}' to '{self.target}'"

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -10,6 +10,21 @@ import tsrc.file_system
 
 
 @attr.s(frozen=True)
+class Repo:
+    dest = attr.ib()  # type: str
+    remotes = attr.ib()  # type: List[Remote]
+    branch = attr.ib(default="master")  # type: str
+    sha1 = attr.ib(default=None)  # type: Optional[str]
+    tag = attr.ib(default=None)  # type: Optional[str]
+    shallow = attr.ib(default=False)  # type: bool
+
+    @property
+    def clone_url(self) -> str:
+        assert self.remotes
+        return self.remotes[0].url
+
+
+@attr.s(frozen=True)
 class Remote:
     name = attr.ib()  # type: str
     url = attr.ib()  # type: str
@@ -53,18 +68,3 @@ class Link(FileSystemOperation):
 
     def __str__(self) -> str:
         return f"link from '{self.source}' to '{self.target}'"
-
-
-@attr.s(frozen=True)
-class Repo:
-    dest = attr.ib()  # type: str
-    remotes = attr.ib()  # type: List[Remote]
-    branch = attr.ib(default="master")  # type: str
-    sha1 = attr.ib(default=None)  # type: Optional[str]
-    tag = attr.ib(default=None)  # type: Optional[str]
-    shallow = attr.ib(default=False)  # type: bool
-
-    @property
-    def clone_url(self) -> str:
-        assert self.remotes
-        return self.remotes[0].url

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -1,4 +1,4 @@
-""" Repo objects """
+""" Repo objects. """
 from typing import Optional, List  # noqa
 
 import attr
@@ -7,6 +7,8 @@ import attr
 @attr.s(frozen=True)
 class Repo:
     dest = attr.ib()  # type: str
+    # Note: a repo has at least one remote called 'origin' by default -
+    # other remotes may be configured explicitly in the manifest file.
     remotes = attr.ib()  # type: List[Remote]
     branch = attr.ib(default="master")  # type: str
     sha1 = attr.ib(default=None)  # type: Optional[str]

--- a/tsrc/test/conftest.py
+++ b/tsrc/test/conftest.py
@@ -1,4 +1,4 @@
-""" Fixtures for tsrc testing """
+""" Fixtures for tsrc testing. """
 
 from typing import Any, Iterator
 from path import Path
@@ -13,7 +13,7 @@ from .helpers.cli import tsrc_cli  # noqa
 
 @pytest.fixture()
 def tmp_path(tmpdir: Any) -> Path:
-    """ Convert py.path.Local() to Path() objects """
+    """ Convert py.path.Local() to Path() objects. """
     return Path(tmpdir.strpath)
 
 

--- a/tsrc/test/helpers/__init__.py
+++ b/tsrc/test/helpers/__init__.py
@@ -1,0 +1,1 @@
+""" Contains code that is only used by tests. """

--- a/tsrc/test/helpers/cli.py
+++ b/tsrc/test/helpers/cli.py
@@ -1,3 +1,8 @@
+""" Helper to cal tsrc's main() function.
+
+Used by the `tsrc_cli` fixture.
+"""
+
 from typing import Any, Type
 import os
 

--- a/tsrc/test/helpers/git_server.py
+++ b/tsrc/test/helpers/git_server.py
@@ -1,4 +1,11 @@
+""" The GitServer class can create bare git repositories and a manifest
+that contains valid git URLs.
+
+It is mostly used by the end-to-end tests in tsrc/test/cli/.
+"""
+
 from typing import cast, Any, Dict, List, Tuple, Optional
+
 import ruamel.yaml
 import pytest
 
@@ -11,6 +18,8 @@ RemoteConfig = Tuple[str, str]
 
 
 class BareRepo:
+    """ Simple wrapper over pygit2. """
+
     user = pygit2.Signature("Tasty Test", "test@tsrc.io")
 
     def __init__(self, path: Path) -> None:
@@ -76,7 +85,18 @@ class BareRepo:
 
 
 class ManifestHandler:
+    """ Contains methods to update repositories configuration
+    in the manifest repo.
+
+    Data is written directly to the underlying BareRepo instance,
+    using `refs/heads/master` ref by default.
+
+    After a call `change_branch(new_branch)`, changes will be
+    written to refs/heads/new_branch` instead.
+    """
+
     def __init__(self, repo: BareRepo) -> None:
+
         self.repo = repo
         self.data = {"repos": []}  # type: Dict[str, Any]
         self.branch = "master"
@@ -157,6 +177,14 @@ class ManifestHandler:
 
 
 class GitServer:
+    """
+    Holds a collection of git repositories in `self.bare_path, itself a
+    subdirectory of `tmpdir`.
+
+    Also uses a ManifestHandler instance to update the manifest
+    configuration, like adding a new repo.
+    """
+
     def __init__(self, tmpdir: Path) -> None:
         self.tmpdir = tmpdir
         self.bare_path = tmpdir / "srv"

--- a/tsrc/test/test_config.py
+++ b/tsrc/test/test_config.py
@@ -25,7 +25,7 @@ def test_invalid_syntax(tmp_path: Path) -> None:
     )
     with pytest.raises(tsrc.InvalidConfig) as e:
         dummy_schema = mock.Mock()
-        tsrc.parse_config(foo_yml, dummy_schema)
+        tsrc.parse_config(foo_yml, schema=dummy_schema)
     raised_error = e.value
     assert raised_error.config_path == foo_yml
     assert isinstance(raised_error.cause, ruamel.yaml.error.YAMLError)
@@ -43,7 +43,7 @@ def test_invalid_schema(tmp_path: Path) -> None:
     )
     foo_schema = schema.Schema({"foo": {"bar": str}})
     with pytest.raises(tsrc.InvalidConfig) as e:
-        tsrc.parse_config(foo_yml, foo_schema)
+        tsrc.parse_config(foo_yml, schema=foo_schema)
     assert isinstance(e.value.cause, schema.SchemaError)
 
 
@@ -54,5 +54,5 @@ def test_use_pure_python_types(tmp_path: Path) -> None:
     foo_yml = tmp_path / "foo.yml"
     foo_yml.write_text("foo: 42\n")
     foo_schema = schema.Schema({"foo": int})
-    parsed = tsrc.parse_config(foo_yml, foo_schema)
+    parsed = tsrc.parse_config(foo_yml, schema=foo_schema)
     assert type(parsed) == type({})  # noqa

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -50,7 +50,7 @@ class Workspace:
 
         # Note: at this point the repositories on which the user wishes to
         # execute an action is unknown. This list will be set after processing
-        # the command line arguments (like `--group` or `--all-cloned`)
+        # the command line arguments (like `--group` or `--all-cloned`).
         #
         # In particular, you _cannot assume_ that every repo in this list was
         # cloned - in other words, don't use `workspace.root_path / repo.dest`

--- a/tsrc/workspace/cloner.py
+++ b/tsrc/workspace/cloner.py
@@ -11,6 +11,8 @@ import tsrc.executor
 
 
 class Cloner(tsrc.executor.Task[tsrc.Repo]):
+    """ Implement cloning missing repos. """
+
     def __init__(
         self,
         workspace_path: Path,
@@ -54,6 +56,12 @@ class Cloner(tsrc.executor.Task[tsrc.Repo]):
         return repo.remotes[0]
 
     def clone_repo(self, repo: tsrc.Repo) -> None:
+        """ Clone a missing repo.
+
+        Note: must use the correct remote(s) and branch when cloning,
+        *and* must reset the repo to the correct state if `tag` or
+        `sha1` were set in the manifest configuration.
+        """
         repo_path = self.workspace_path / repo.dest
         parent, name = repo_path.splitpath()
         parent.makedirs_p()

--- a/tsrc/workspace/config.py
+++ b/tsrc/workspace/config.py
@@ -6,7 +6,12 @@ import ruamel.yaml
 
 @attr.s
 class WorkspaceConfig:
-    """ Persistent configuration of the workspace """
+    """ Persistent configuration of the workspace.
+
+    Stored in <workspace>/.tsrc/config.yml, and can be
+    edited by hand to use a different set of groups
+    for instance.
+    """
 
     manifest_url = attr.ib()  # type: str
     manifest_branch = attr.ib()  # type: str

--- a/tsrc/workspace/file_system_operator.py
+++ b/tsrc/workspace/file_system_operator.py
@@ -8,6 +8,11 @@ import tsrc.executor
 
 
 class FileSystemOperator(tsrc.executor.Task[tsrc.FileSystemOperation]):
+    """ Implement file system operations to be run once every missing
+    repo has been cloned, like copying files or creating symlinks.
+
+    """
+
     def __init__(self, workspace_path: Path, repos: List[tsrc.Repo]) -> None:
         self.workspace_path = workspace_path
         self.repos = repos

--- a/tsrc/workspace/local_manifest.py
+++ b/tsrc/workspace/local_manifest.py
@@ -6,8 +6,19 @@ import tsrc.manifest
 
 
 class LocalManifest:
-    """ Represent a manifest that has been cloned locally inside the
-    hidden <workspace>/.tsrc/manifest
+    """ Represent a manifest repository that has been cloned locally
+    inside `<workspace>/.tsrc/manifest`.
+
+    Usage:
+
+    >>> local_manifest = LocalManifest(Path(workspace / ".tsrc/manifest")
+
+    # First, update the cloned repository using a remote git URL and a
+    # branch:
+    >>> manifest.update("git@acme.com/manifest.git", branch="devel")
+
+    # Then, read the `manifest.yml` file from the clone repository:
+    >>> manifest = local_manifest.get_manifest()
 
     """
 

--- a/tsrc/workspace/remote_setter.py
+++ b/tsrc/workspace/remote_setter.py
@@ -20,12 +20,6 @@ class RemoteSetter(tsrc.executor.Task[tsrc.Repo]):
         return repo.dest
 
     def process(self, index: int, count: int, repo: tsrc.Repo) -> None:
-        try:
-            self.try_process_repo(repo)
-        except Exception:
-            raise tsrc.Error(repo.dest, ":", "Failed to configure remotes")
-
-    def try_process_repo(self, repo: tsrc.Repo) -> None:
         for remote in repo.remotes:
             existing_remote = self.get_remote(repo, remote.name)
             if existing_remote:

--- a/tsrc/workspace/remote_setter.py
+++ b/tsrc/workspace/remote_setter.py
@@ -7,6 +7,15 @@ import tsrc.executor
 
 
 class RemoteSetter(tsrc.executor.Task[tsrc.Repo]):
+    """
+    For each repository:
+
+      * look for the remote configured in the manifest,
+      * add any missing remote,
+      * if a remote is found but with an incorrect URL, update its URL.
+
+    """
+
     def __init__(self, workspace_path: Path) -> None:
         self.workspace_path = workspace_path
 

--- a/tsrc/workspace/syncer.py
+++ b/tsrc/workspace/syncer.py
@@ -42,6 +42,16 @@ class Syncer(tsrc.executor.Task[tsrc.Repo]):
         return repo.dest
 
     def process(self, index: int, count: int, repo: tsrc.Repo) -> None:
+        """ Synchronize a repo given its configuration in the manifest.
+
+        Always start by running `git fetch`, then either:
+
+        * try resetting the repo to the given tag or sha1 (abort
+          if the repo is dirty)
+
+        * or try merging the local branch with its upstream (abort if not
+          on on the correct branch, or if the merge is not fast-forward).
+        """
         ui.info_count(index, count, repo.dest)
         repo_path = self.workspace_path / repo.dest
         self.fetch(repo)


### PR DESCRIPTION
Note: the last commit contains a few trivial refactorings, that should be extracted into their own commits:

* move Copy, Link and FileSystemOperation from tsrc/repo.py to tsrc/file_system.py
* parse_config: schema is no longer optional
* RemoteSetter: remove try/catch
* move Remote class below Repo class
