### PR TITLE
Implement --no-update-manifest flag for sync

### DIFF
--- a/tsrc/cli/sync.py
+++ b/tsrc/cli/sync.py
@@ -14,12 +14,16 @@ def sync(
     groups: Optional[List[str]] = None,
     all_cloned: bool = False,
     force: bool = False,
+    no_update_manifest: bool = False,
 ) -> None:
     """ synchronize the current workspace with the manifest """
     workspace = get_workspace(workspace_path)
 
-    ui.info_2("Updating manifest")
-    workspace.update_manifest()
+    if no_update_manifest:
+        ui.info_2("Not updating manifest")
+    else:
+        ui.info_2("Updating manifest")
+        workspace.update_manifest()
 
     workspace.repos = resolve_repos(workspace, groups=groups, all_cloned=all_cloned)
     workspace.clone_missing()


### PR DESCRIPTION
Hi! I had already opened this MR on Gitlab, but then the project was moved back here. So here I go again:

This new flag does not update the manifest before executing a sync. This
is useful if one has unstaged changes in the manifest, and does not wish
for them to be discarded by an update.

I implemented this because I needed to modify the manifest and then perform a `tsrc sync`, in a CI environment. I run a `sed` script over the manifest to update all URLs, but then `tsrc sync` just discards my changes, so the `--no-update-manifest` flag helped me. Looking forward to your feedback!