### PR TITLE
Add support for manifests and sub-repositories in a single repository

### DIFF
--- a/tsrc/cli/init.py
+++ b/tsrc/cli/init.py
@@ -51,8 +51,16 @@ def run(args: argparse.Namespace) -> None:
 
     ui.info_1("Configuring workspace in", ui.bold, workspace_path)
 
+    manifest_file = Path(args.manifest_url)
+    if manifest_file.exists():
+        manifest_url = str(
+            manifest_file.absolute().relative_to(Path(workspace_path).absolute())
+        )
+    else:
+        manifest_url = args.manifest_url
+
     workspace_config = WorkspaceConfig(
-        manifest_url=args.manifest_url,
+        manifest_url=manifest_url,
         manifest_branch=args.manifest_branch,
         clone_all_repos=args.clone_all_repos,
         repo_groups=args.groups or [],

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -47,6 +47,12 @@ class Workspace:
             raise WorkspaceNotConfigured(root_path)
 
         self.config = WorkspaceConfig.from_file(self.cfg_path)
+        manifest_file = root_path / self.config.manifest_url
+        if manifest_file.is_file():
+            manifest_file = manifest_file.absolute()
+            self.local_manifest = LocalManifest(
+                manifest_file.parent, manifest_file.name, remote_repo=False
+            )
 
         # Note: at this point the repositories on which the user wishes to
         # execute an action is unknown. This list will be set after processing
@@ -66,6 +72,10 @@ class Workspace:
 
     def update_manifest(self) -> None:
         manifest_url = self.config.manifest_url
+        manifest_file = self.root_path / manifest_url
+        if manifest_file.is_dir():
+            manifest_file = manifest_file.absolute()
+            manifest_url = str(manifest_file)
         manifest_branch = self.config.manifest_branch
         self.local_manifest.update(url=manifest_url, branch=manifest_branch)
 

--- a/tsrc/workspace/local_manifest.py
+++ b/tsrc/workspace/local_manifest.py
@@ -22,17 +22,22 @@ class LocalManifest:
 
     """
 
-    def __init__(self, clone_path: Path) -> None:
+    def __init__(
+        self, clone_path: Path, manifest_filename="manifest.yml", remote_repo=True
+    ) -> None:
         self.clone_path = clone_path
+        self.manifest_filename = manifest_filename
+        self.remote_repo = remote_repo
 
     def update(self, url: str, *, branch: str) -> None:
         if self.clone_path.exists():
-            self._reset_manifest_clone(url, branch=branch)
+            if self.remote_repo:
+                self._reset_manifest_clone(url, branch=branch)
         else:
             self._clone_manifest(url, branch=branch)
 
     def get_manifest(self) -> tsrc.manifest.Manifest:
-        return tsrc.manifest.load(self.clone_path / "manifest.yml")
+        return tsrc.manifest.load(self.clone_path / self.manifest_filename)
 
     def _reset_manifest_clone(self, url: str, *, branch: str) -> None:
         tsrc.git.run(self.clone_path, "remote", "set-url", "origin", url)


### PR DESCRIPTION
This PR is mainly a suggestion and just a hack to implement some functionality I would like to have.
I would like to have a single git repository that contains the manifest and some source code. Instead of using git submodules, I would like to use tsrc to update all external git repositories. I have changed a logic if the URI passed to tsrc init is a path to a file and directory.
If it is a file, it should be in the workspace directory and assumed to be a manifest, and no cloned repository .tsrc/manifest is created. If URI is a directory, it should be a local Git repository and will be cloned to .tsrc/manifest; this did not work if URI was a relative path.