### PR TITLE
Always display workspace path

### DIFF
--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -25,6 +25,7 @@ def add_workspace_arg(parser: argparse.ArgumentParser) -> None:
 
 def get_workspace(namespace: argparse.Namespace) -> Workspace:
     workspace_path = namespace.workspace_path or find_workspace_path()
+    ui.info_1("Using workspace in", ui.bold, workspace_path)
     return tsrc.Workspace(workspace_path)
 
 


### PR DESCRIPTION
Apparently it's not clear that `tsrc` can work from any directory inside the workspace. See #298 