### PR TITLE
Use parallel executor by default

### DIFF
--- a/docs/ref/cli.md
+++ b/docs/ref/cli.md
@@ -27,11 +27,12 @@ First, note that like `git`, tsrc will walk up the folders hierarchy
 looking for a `.tsrc` folder, which means you can run tsrc commands
 anywhere in your workspace, not just at the top.
 
-Second, almost all commands allow a `-j` option to run the operation in
-parallel. For instance, `tsrc sync -j auto` will use as many jobs as the
-number of CPUs available on the current machine to synchronize the repos
-in your workspace. If this behavior is not desired, you can specify a
-greater (or lower) number of jobs using something like `tsrc sync -j2`.
+Second, almost all commands run the operation in parallel. For instance,
+`tsrc sync` by default will use as many jobs as the number of CPUs
+available on the current machine to synchronize the repos in your workspace.
+If this behavior is not desired, you can specify a greater (or lower)
+number of jobs using something like `tsrc sync -j2`, or disable the
+parallelism completely with `-j1`.
 
 ## Global options
 

--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -32,15 +32,13 @@ def add_num_jobs_arg(parser: argparse.ArgumentParser) -> None:
         "-j",
         "--jobs",
         dest="num_jobs",
-        help="Number of jobs to use simultaneously",
+        help="Number of jobs to use simultaneously (1 to disable parallelism)",
     )
 
 
-def get_num_jobs(args: argparse.Namespace) -> Optional[int]:
+def get_num_jobs(args: argparse.Namespace) -> int:
     value = args.num_jobs
-    if value is None:
-        return None
-    if value == "auto":
+    if value in [None, "auto"]:
         return cpu_count()
     try:
         return int(value)

--- a/tsrc/executor.py
+++ b/tsrc/executor.py
@@ -18,7 +18,7 @@ the Task[T] interface
 
 ## Running tasks
 
-* If num_jobs is None, the SequentialExecutor is used,
+* If num_jobs is 1, the SequentialExecutor is used,
   otherwise the ParallelExecutor is used. The  `parallel` boolean
   attribute on the Task instances is set accordingly.
 * Both the SequentialExecutor and the ParallelExecutor will call
@@ -319,9 +319,9 @@ class ParallelExecutor(Generic[T]):
 
 
 def process_items(
-    items: List[T], task: Task[T], *, num_jobs: Optional[int] = None
+    items: List[T], task: Task[T], *, num_jobs: int = 1
 ) -> OutcomeCollection:
-    if num_jobs:
+    if num_jobs > 1:
         res = process_items_parallel(items, task, num_jobs=num_jobs)
     else:
         res = process_items_sequence(items, task)

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -70,7 +70,7 @@ class Workspace:
         manifest_branch = self.config.manifest_branch
         self.local_manifest.update(url=manifest_url, branch=manifest_branch)
 
-    def clone_missing(self, *, num_jobs: Optional[int] = None) -> None:
+    def clone_missing(self, *, num_jobs: int = 1) -> None:
         to_clone = []
         for repo in self.repos:
             repo_path = self.root_path / repo.dest
@@ -92,7 +92,7 @@ class Workspace:
             collection.print_errors()
             raise ClonerError
 
-    def set_remotes(self, num_jobs: Optional[int] = None) -> None:
+    def set_remotes(self, num_jobs: int = 1) -> None:
         if self.config.singular_remote:
             return
         ui.info_2("Configuring remotes")
@@ -117,14 +117,14 @@ class Workspace:
         if operations:
             ui.info_2("Performing filesystem operations")
             # Not sure it's a good idea to have FileSystemOperations running in parallel
-            collection = process_items(operations, operator, num_jobs=None)
+            collection = process_items(operations, operator, num_jobs=1)
             collection.print_summary()
             if collection.errors:
                 ui.error("Failed to perform the following file system operations")
                 collection.print_errors()
                 raise FileSystemOperatorError
 
-    def sync(self, *, force: bool = False, num_jobs: Optional[int] = None) -> None:
+    def sync(self, *, force: bool = False, num_jobs: int = 1) -> None:
         syncer = Syncer(
             self.root_path, force=force, remote_name=self.config.singular_remote
         )


### PR DESCRIPTION
with the number of jobs equal to the
number of CPU cores. Pass 1 to -j to
disable the parallelism.

Fixes #323.