### PR TITLE
Add an `ignore_submodules` option for `tsrc`

### DIFF
--- a/docs/ref/manifest-config.md
+++ b/docs/ref/manifest-config.md
@@ -69,6 +69,10 @@ Each repository is also a *mapping*, containing:
     * When running `tsrc init`: Project will be cloned, and then reset to the given sha1.
     * When running `tsrc sync`:  If the project is clean, project will be reset
     to the given sha1, else a warning message will be printed.
+* `ignore_submodules` (optional, default=`false`):
+    * When running `tsrc init`: if `ignore_submodules` is `true`, do not recursively clone submodules.
+    * When running `tsrc sync`: if `ignore_submodules` is `true`, do not initialize or update submodules.
+    to the given sha1, else a warning message will be printed.
 * `copy` (optional): A list of mappings with `file` and `dest` keys.
 * `symlink` (optional): A list of mappings with `source` and `target` keys.
 

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -58,7 +58,14 @@ class Manifest:
             remotes = [origin]
         else:
             remotes = self._handle_remotes(repo_config)
-        repo = Repo(dest=dest, branch=branch, sha1=sha1, tag=tag, remotes=remotes, ignore_submodules=ignore_submodules)
+        repo = Repo(
+            dest=dest,
+            branch=branch,
+            sha1=sha1,
+            tag=tag,
+            remotes=remotes,
+            ignore_submodules=ignore_submodules,
+        )
         self._repos.append(repo)
 
     def _handle_remotes(self, repo_config: Any) -> List[Remote]:

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -52,12 +52,13 @@ class Manifest:
         tag = repo_config.get("tag")
         sha1 = repo_config.get("sha1")
         url = repo_config.get("url")
+        ignore_submodules = repo_config.get("ignore_submodules", False)
         if url:
             origin = Remote(name="origin", url=url)
             remotes = [origin]
         else:
             remotes = self._handle_remotes(repo_config)
-        repo = Repo(dest=dest, branch=branch, sha1=sha1, tag=tag, remotes=remotes)
+        repo = Repo(dest=dest, branch=branch, sha1=sha1, tag=tag, remotes=remotes, ignore_submodules=ignore_submodules)
         self._repos.append(repo)
 
     def _handle_remotes(self, repo_config: Any) -> List[Remote]:
@@ -144,6 +145,7 @@ def validate_repo(data: Any) -> None:
             schema.Optional("symlink"): [symlink_schema],
             schema.Optional("sha1"): str,
             schema.Optional("tag"): str,
+            schema.Optional("ignore_submodules"): bool,
             schema.Optional("remotes"): [remote_schema],
             schema.Optional("url"): str,
         }

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -20,6 +20,7 @@ class Repo:
     sha1: Optional[str] = attr.ib(default=None)
     tag: Optional[str] = attr.ib(default=None)
     shallow: bool = attr.ib(default=False)
+    ignore_submodules: bool = attr.ib(default=False)
 
     @property
     def clone_url(self) -> str:

--- a/tsrc/test/helpers/git_server.py
+++ b/tsrc/test/helpers/git_server.py
@@ -216,6 +216,9 @@ class ManifestHandler:
     def set_repo_tag(self, name: str, tag: str) -> None:
         self.configure_repo(name, "tag", tag)
 
+    def set_ignore_submodules(self, name: str, ignored: bool) -> None:
+        self.configure_repo(name, "ignore_submodules", ignored)
+
     def set_file_copy(self, repo_name: str, src: str, dest: str) -> None:
         copies = [{"file": src, "dest": dest}]
         self.configure_repo(repo_name, "copy", copies)

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -33,6 +33,7 @@ repos:
     symlink:
       - source: some_source
         target: some_target
+    ignore_submodules: true
 """
     manifest = Manifest()
     parsed = ruamel.yaml.safe_load(contents)
@@ -44,6 +45,7 @@ repos:
             branch="next",
             sha1=None,
             tag=None,
+            ignore_submodules=False,
         ),
         Repo(
             remotes=[Remote(name="origin", url="git@example.com:bar.git")],
@@ -51,6 +53,7 @@ repos:
             branch="master",
             sha1="ad2b68539c78e749a372414165acdf2a1bb68203",
             tag=None,
+            ignore_submodules=False
         ),
         Repo(
             remotes=[Remote(name="origin", url="git@example.com:master.git")],
@@ -58,6 +61,7 @@ repos:
             branch="master",
             sha1=None,
             tag="v0.1",
+            ignore_submodules=True
         ),
     ]
     assert manifest.file_system_operations == [

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -53,7 +53,7 @@ repos:
             branch="master",
             sha1="ad2b68539c78e749a372414165acdf2a1bb68203",
             tag=None,
-            ignore_submodules=False
+            ignore_submodules=False,
         ),
         Repo(
             remotes=[Remote(name="origin", url="git@example.com:master.git")],
@@ -61,7 +61,7 @@ repos:
             branch="master",
             sha1=None,
             tag="v0.1",
-            ignore_submodules=True
+            ignore_submodules=True,
         ),
     ]
     assert manifest.file_system_operations == [

--- a/tsrc/workspace/cloner.py
+++ b/tsrc/workspace/cloner.py
@@ -77,7 +77,8 @@ class Cloner(Task[Repo]):
             clone_args.extend(["--branch", ref])
         if self.shallow:
             clone_args.extend(["--depth", "1"])
-        clone_args.append("--recurse-submodules")
+        if not repo.ignore_submodules:
+            clone_args.append("--recurse-submodules")
         clone_args.append(name)
         try:
             self.run_git(parent, *clone_args)

--- a/tsrc/workspace/syncer.py
+++ b/tsrc/workspace/syncer.py
@@ -72,9 +72,10 @@ class Syncer(Task[Repo]):
                 title = f"{repo.dest} on {current_branch}"
                 summary_lines += [title, "-" * len(title), sync_summary]
 
-        submodule_line = self.update_submodules(repo)
-        if submodule_line:
-            summary_lines.append(submodule_line)
+        if not repo.ignore_submodules:
+            submodule_line = self.update_submodules(repo)
+            if submodule_line:
+                summary_lines.append(submodule_line)
 
         summary = "\n".join(summary_lines)
         return Outcome(error=error, summary=summary)


### PR DESCRIPTION
This is an implementation for the an `ignore_submodules`  option in the manifest. As its name suggests, it allows disabling git submodule managment for some specific repositories (when `ignore_submodules` is `true`). Those patches do not modify the default behavior of `tsrc`, which is to clone & update the submodules (i.e., `ignore_submodules` is `false`).

```yaml
repos:
  - dest: foo
    url: git@example.com:foo.git
    ignore_submodules: true
```

More background in issue #322.