### PR TITLE
Try getting the default `jobs` value from environment

### DIFF
--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -38,6 +38,8 @@ def add_num_jobs_arg(parser: argparse.ArgumentParser) -> None:
 
 def get_num_jobs(args: argparse.Namespace) -> int:
     value = args.num_jobs
+    if value is None:
+        value = os.environ.get("TSRC_PARALLEL_JOBS")
     if value in [None, "auto"]:
         return cpu_count()
     try:


### PR DESCRIPTION


As described in #327.
Allows setting default jobs number using `TSRC_PARALLEL_JOBS` environment variable. It's still possible to provide number of jobs on command line, in which case the env value is ignored.