### PR TITLE
Fix number of jobs command line parsing

### DIFF
--- a/docs/ref/cli.md
+++ b/docs/ref/cli.md
@@ -32,7 +32,8 @@ Second, almost all commands run the operation in parallel. For instance,
 available on the current machine to synchronize the repos in your workspace.
 If this behavior is not desired, you can specify a greater (or lower)
 number of jobs using something like `tsrc sync -j2`, or disable the
-parallelism completely with `-j1`.
+parallelism completely with `-j1`. You can also set the default number
+of jobs by using  the `TSRC_PARALLEL_JOBS ` environment variable.
 
 ## Global options
 

--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -37,9 +37,12 @@ def add_num_jobs_arg(parser: argparse.ArgumentParser) -> None:
 
 
 def get_num_jobs(args: argparse.Namespace) -> int:
-    value = args.num_jobs
-    if value is None:
-        value = os.environ.get("TSRC_PARALLEL_JOBS")
+    from_command_line = args.num_jobs
+    from_env = os.environ.get("TSRC_PARALLEL_JOBS")
+    if from_command_line:
+        value = from_command_line
+    else:
+        value = from_env
     if value in [None, "auto"]:
         return cpu_count()
     try:

--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -32,7 +32,10 @@ def add_num_jobs_arg(parser: argparse.ArgumentParser) -> None:
         "-j",
         "--jobs",
         dest="num_jobs",
-        help="Number of jobs to use simultaneously (1 to disable parallelism)",
+        help="Number of jobs to use simultaneously. "
+        "Use 1 to disable parallelism. "
+        "Defaults to the value of the "
+        "TSRC_PARALLEL_JOBS environment variable",
     )
 
 

--- a/tsrc/test/cli/test_cli.py
+++ b/tsrc/test/cli/test_cli.py
@@ -1,0 +1,45 @@
+import argparse
+from multiprocessing import cpu_count
+from typing import List
+
+import pytest
+
+from tsrc.cli import add_num_jobs_arg, get_num_jobs
+
+
+class TestNumJobsParsing:
+    def parse_args(self, args: List[str]) -> int:
+        parser = argparse.ArgumentParser()
+        add_num_jobs_arg(parser)
+        parsed = parser.parse_args(args)
+        return get_num_jobs(parsed)
+
+    def test_defaults_to_all_cpus(self) -> None:
+        actual = self.parse_args([])
+        assert actual == cpu_count()
+
+    def test_auto_uses_all_cpus(self) -> None:
+        actual = self.parse_args(["--jobs", "auto"])
+        assert actual == cpu_count()
+
+    def test_specify_num_jobs_explicitly(self) -> None:
+        actual = self.parse_args(["--jobs", "3"])
+        assert actual == 3
+
+    def test_using_env_variable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TSRC_PARALLEL_JOBS", "5")
+        actual = self.parse_args([])
+
+        assert actual == 5
+
+    def test_overriding_env_variable_from_command_line(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TSRC_PARALLEL_JOBS", "5")
+        actual = self.parse_args(["--jobs", "6"])
+
+        assert actual == 6


### PR DESCRIPTION
Follow for #328, by @yawor 

> t's still possible to provide number of jobs on command line, in which case the env value is ignored

I was not sure about that, so I wrote some tests, and I think I found a bug.

Can you please review and confirm I was not mistaken?

Related to #327 