### PR TITLE
Don't hide git commands by default

### DIFF
--- a/tsrc/executor.py
+++ b/tsrc/executor.py
@@ -200,7 +200,7 @@ class Task(Generic[T], metaclass=abc.ABCMeta):
         is captured if the task is run in parallel with other tasks.
         """
         if self.parallel:
-            run_git(working_path, *args, verbose=False)
+            run_git(working_path, *args, show_output=False)
         else:
             run_git(working_path, *args)
 

--- a/tsrc/executor.py
+++ b/tsrc/executor.py
@@ -200,7 +200,7 @@ class Task(Generic[T], metaclass=abc.ABCMeta):
         is captured if the task is run in parallel with other tasks.
         """
         if self.parallel:
-            run_git(working_path, *args, show_output=False)
+            run_git(working_path, *args, show_output=False, show_cmd=False)
         else:
             run_git(working_path, *args)
 

--- a/tsrc/git.py
+++ b/tsrc/git.py
@@ -184,7 +184,11 @@ class GitStatus:
 
 
 def run_git(
-    working_path: Path, *cmd: str, check: bool = True, show_output: bool = True
+    working_path: Path,
+    *cmd: str,
+    check: bool = True,
+    show_output: bool = True,
+    show_cmd: bool = True,
 ) -> None:
     """Run git `cmd` in given `working_path`.
 
@@ -194,7 +198,8 @@ def run_git(
     git_cmd = list(cmd)
     git_cmd.insert(0, "git")
 
-    ui.debug(ui.lightgray, working_path, "$", ui.reset, *git_cmd)
+    if show_cmd:
+        ui.info(ui.blue, "$", ui.reset, *git_cmd)
     if show_output:
         process = subprocess.run(git_cmd, cwd=working_path, universal_newlines=True)
     else:

--- a/tsrc/git.py
+++ b/tsrc/git.py
@@ -184,7 +184,7 @@ class GitStatus:
 
 
 def run_git(
-    working_path: Path, *cmd: str, check: bool = True, verbose: bool = True
+    working_path: Path, *cmd: str, check: bool = True, show_output: bool = True
 ) -> None:
     """Run git `cmd` in given `working_path`.
 
@@ -195,7 +195,7 @@ def run_git(
     git_cmd.insert(0, "git")
 
     ui.debug(ui.lightgray, working_path, "$", ui.reset, *git_cmd)
-    if verbose:
+    if show_output:
         process = subprocess.run(git_cmd, cwd=working_path, universal_newlines=True)
     else:
         process = subprocess.run(

--- a/tsrc/test/cli/test_sync.py
+++ b/tsrc/test/cli/test_sync.py
@@ -34,7 +34,7 @@ def test_sync_happy(tsrc_cli: CLI, git_server: GitServer, workspace_path: Path) 
     assert new_txt_path.exists(), "foo should have been updated"
 
 
-def test_sync_parallel(
+def test_sync_sequential(
     tsrc_cli: CLI, git_server: GitServer, workspace_path: Path
 ) -> None:
     """
@@ -55,7 +55,7 @@ def test_sync_parallel(
     git_server.push_file("bar", "bar1")
     git_server.push_file("bar", "bar2", contents="two\nlines\n")
 
-    tsrc_cli.run("sync", "-j", "2")
+    tsrc_cli.run("sync", "-j", "1")
 
 
 def test_sync_with_errors(


### PR DESCRIPTION
Following several bug reports where we had to run `tsrc --verbose` to figure out what happened :stuck_out_tongue: 