### PR TITLE
Preserve manifest ordering when resolving repositories

### DIFF
--- a/tsrc/groups.py
+++ b/tsrc/groups.py
@@ -1,7 +1,7 @@
 """ Support for groups of elements """
 # Note that groups are allowed to include other groups.
 
-from typing import Any, Dict, Generic, Iterable, List, Optional, Set, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from tsrc.errors import Error
 
@@ -14,7 +14,7 @@ class GroupError(Error):
 
 class Group(Generic[T]):
     def __init__(
-        self, name: str, elements: Iterable[T], includes: Optional[List[str]] = None
+        self, name: str, elements: List[T], includes: Optional[List[str]] = None
     ) -> None:
         self.name = name
         self.elements = elements
@@ -54,13 +54,13 @@ class GroupList(Generic[T]):
 
     """
 
-    def __init__(self, *, elements: Iterable[T]) -> None:
+    def __init__(self, *, elements: List[T]) -> None:
         self.groups: Dict[str, Group[T]] = {}
         self.all_elements = elements
-        self._groups_seen: Set[str] = set()
+        self._groups_seen: List[str] = []
 
     def add(
-        self, name: str, elements: Iterable[T], includes: Optional[List[str]] = None
+        self, name: str, elements: List[T], includes: Optional[List[str]] = None
     ) -> None:
         for element in elements:
             if element not in self.all_elements:
@@ -70,20 +70,20 @@ class GroupList(Generic[T]):
     def get_group(self, name: str) -> Optional[Group[T]]:
         return self.groups.get(name)
 
-    def get_elements(self, groups: List[str]) -> Iterable[T]:
+    def get_elements(self, groups: List[str]) -> List[T]:
         # Note: to get all elements in a group, recursively parse
         # the groups and their includes, while making sure no
         # group is processed twice.
         #
         # This algorithms allows to have groups that include each other
         # without creating infinite loops.
-        self._groups_seen = set()
-        res: Set[T] = set()
+        self._groups_seen = []
+        res: List[T] = []
         self._rec_get_elements(res, groups, parent_group=None)
         return res
 
     def _rec_get_elements(
-        self, res: Set[T], group_names: List[str], *, parent_group: Optional[Group[T]]
+        self, res: List[T], group_names: List[str], *, parent_group: Optional[Group[T]]
     ) -> None:
         for group_name in group_names:
             if group_name in self._groups_seen:
@@ -92,6 +92,6 @@ class GroupList(Generic[T]):
                 raise GroupNotFound(group_name, parent_group=parent_group)
             group = self.groups[group_name]
             for element in group.elements:
-                res.add(element)
-            self._groups_seen.add(group.name)
+                res.append(element)
+            self._groups_seen.append(group.name)
             self._rec_get_elements(res, group.includes, parent_group=group)

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -2,7 +2,6 @@
 
 # TODO: check for absolute paths in _handle_copies, _handle_links
 
-import operator
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -98,7 +97,7 @@ class Manifest:
             self.file_system_operations.append(link)
 
     def _handle_groups(self, groups_config: Any) -> None:
-        elements = {repo.dest for repo in self._repos}
+        elements = [repo.dest for repo in self._repos]
         self.group_list = GroupList(elements=elements)
         if not groups_config:
             return
@@ -131,7 +130,7 @@ class Manifest:
         res = []
         for dest in elements:
             res.append(self.get_repo(dest))
-        return sorted(res, key=operator.attrgetter("dest"))
+        return res
 
     def get_repo(self, dest: str) -> Repo:
         for repo in self._repos:

--- a/tsrc/test/test_groups.py
+++ b/tsrc/test/test_groups.py
@@ -4,25 +4,25 @@ from tsrc.groups import GroupList, GroupNotFound, UnknownGroupElement
 
 
 def test_happy_grouping() -> None:
-    group_list = GroupList(elements={"a", "b", "b", "c"})
-    group_list.add("default", {"a", "b"})
-    group_list.add("other", {"c"}, includes=["default"])
+    group_list = GroupList(elements=["a", "b", "b", "c"])
+    group_list.add("default", ["a", "b"])
+    group_list.add("other", ["c"], includes=["default"])
     actual = group_list.get_elements(groups=["other"])
-    assert actual == {"a", "b", "c"}
+    assert actual == ["c", "a", "b"]
 
 
 def test_unknown_element() -> None:
-    group_list = GroupList(elements={"a", "b", "c"})
+    group_list = GroupList(elements=["a", "b", "c"])
     with pytest.raises(UnknownGroupElement) as e:
-        group_list.add("invalid-group", {"no-such-element"})
+        group_list.add("invalid-group", ["no-such-element"])
     assert e.value.group_name == "invalid-group"
     assert e.value.element == "no-such-element"
 
 
 def test_unknown_include() -> None:
-    group_list = GroupList(elements={"a", "b", "c"})
-    group_list.add("default", {"a", "b"})
-    group_list.add("invalid-group", {"c"}, includes=["no-such-group"])
+    group_list = GroupList(elements=["a", "b", "c"])
+    group_list.add("default", ["a", "b"])
+    group_list.add("invalid-group", ["c"], includes=["no-such-group"])
     with pytest.raises(GroupNotFound) as e:
         group_list.get_elements(groups=["invalid-group"])
     assert e.value.parent_group is not None
@@ -31,35 +31,35 @@ def test_unknown_include() -> None:
 
 
 def test_diamond() -> None:
-    group_list = GroupList(elements={"a", "b", "c", "d"})
-    group_list.add("top", {"a"})
-    group_list.add("left", {"b"}, includes=["top"])
-    group_list.add("right", {"c"}, includes=["top"])
-    group_list.add("bottom", {"d"}, includes=["left", "right"])
+    group_list = GroupList(elements=["a", "b", "c", "d"])
+    group_list.add("top", ["a"])
+    group_list.add("left", ["b"], includes=["top"])
+    group_list.add("right", ["c"], includes=["top"])
+    group_list.add("bottom", ["d"], includes=["left", "right"])
     actual = group_list.get_elements(groups=["bottom"])
-    assert actual == {"a", "b", "c", "d"}
+    assert actual == ["d", "b", "a", "c"]
 
 
 def test_ping_pong() -> None:
-    group_list = GroupList(elements={"a", "b"})
-    group_list.add("ping", {"a"}, includes=["pong"])
-    group_list.add("pong", {"b"}, includes=["ping"])
+    group_list = GroupList(elements=["a", "b"])
+    group_list.add("ping", ["a"], includes=["pong"])
+    group_list.add("pong", ["b"], includes=["ping"])
     actual = group_list.get_elements(groups=["ping"])
-    assert actual == {"a", "b"}
+    assert actual == ["a", "b"]
 
 
 def test_circle() -> None:
-    group_list = GroupList(elements={"a", "b", "c"})
-    group_list.add("a", {"a"}, includes=["b"])
-    group_list.add("b", {"b"}, includes=["c"])
-    group_list.add("c", {"c"}, includes=["a"])
+    group_list = GroupList(elements=["a", "b", "c"])
+    group_list.add("a", ["a"], includes=["b"])
+    group_list.add("b", ["b"], includes=["c"])
+    group_list.add("c", ["c"], includes=["a"])
     actual = group_list.get_elements(groups=["a"])
-    assert actual == {"a", "b", "c"}
+    assert actual == ["a", "b", "c"]
 
 
 def test_unknown_group() -> None:
-    group_list = GroupList(elements={"a", "b", "c"})
-    group_list.add("default", {"a", "b"})
+    group_list = GroupList(elements=["a", "b", "c"])
+    group_list.add("default", ["a", "b"])
     with pytest.raises(GroupNotFound) as e:
         group_list.get_elements(groups=["no-such-group"])
     assert e.value.parent_group is None

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -262,7 +262,7 @@ groups:
       includes: [b_group]
 """
     repos_getter.contents = contents
-    assert repos_getter.get_repos(groups=["c_group"]) == ["a", "b", "c"]
+    assert repos_getter.get_repos(groups=["c_group"]) == ["c", "b", "a"]
 
 
 def test_all_repos(repos_getter: ReposGetter) -> None:


### PR DESCRIPTION
This allows the user to control the order of operations (assuming they're
using `-j 1`)

If for whatever reason, `foo` must be cloned before `bar` just make sure
`foo` is mentioned before `bar` in the manifest.

Fix #352 