### PR TITLE
Breaking: correct branch on clean repos during sync by default

### DIFF
--- a/docs/ref/cli.md
+++ b/docs/ref/cli.md
@@ -97,10 +97,10 @@ tsrc status
     * Shows dirty repositories
     * Shows repositories not on the expected branch
 
-tsrc sync [--correct-branch/-c]
+tsrc sync [--no-correct-branch]
 :   Updates all the repositories and shows a summary at the end.
     If any of the repositories is not on the configured branch, but it is clean
-    and the `--correct-branch`/`-c` flag is set, then the branch is changed to
+    and the `--no-correct-branch` flag is NOT set, then the branch is changed to
     the configured one and then the repository is updated. Otherwise that repository
     will not be not updated.
 

--- a/docs/ref/sync.md
+++ b/docs/ref/sync.md
@@ -7,9 +7,10 @@ Here's the algorithm that is used:
 
 * Run `git fetch --tags --prune`
 * Check if the repository is on a branch
-* Check if the currently checked out branch matches the one configured in
-  the manifest. If it does not but the `--correct-branch` flag is set
-  and the repository is clean, the branch is changed to the configured one. 
+* Check if the currently checked out branch matches the one configured
+  in the manifest. If it does not, the repository is clean and the
+  `--no-correct-branch` flag is NOT set, the branch is changed to the
+  configured one.
 * Check if the repository is dirty
 * Try and run a fast-forward merge
 

--- a/tsrc/cli/sync.py
+++ b/tsrc/cli/sync.py
@@ -18,7 +18,7 @@ def configure_parser(subparser: argparse._SubParsersAction) -> None:
     parser = subparser.add_parser("sync")
     add_workspace_arg(parser)
     add_repos_selection_args(parser)
-    parser.set_defaults(update_manifest=True, force=False, correct_branch=False)
+    parser.set_defaults(update_manifest=True, force=False, correct_branch=True)
     parser.add_argument(
         "--force", help="use `git fetch --force` while syncing", action="store_true"
     )
@@ -29,11 +29,10 @@ def configure_parser(subparser: argparse._SubParsersAction) -> None:
         help="skip updating the manifest before syncing repositories",
     )
     parser.add_argument(
-        "--correct-branch",
-        "-c",
-        action="store_true",
+        "--no-correct-branch",
+        action="store_false",
         dest="correct_branch",
-        help="go back to the configured branch, if the repo is clean",
+        help="prevent going back to the configured branch, if the repo is clean",
     )
     add_num_jobs_arg(parser)
     parser.set_defaults(run=run)


### PR DESCRIPTION
After merging https://github.com/your-tools/tsrc/pull/362 we would have to uptick the major version as it's a backward incompatible change (`-i` flag will work exactly the opposite way).

If so, then I would like to make another backward-incompatible change in v3.0.0 of tsrc - this one.

This new default sync behavior is widely preferred in my company where we have a lot of tsrc users.