### PR TITLE
feat-manifest-management: introducing 'manifest' command option

### DIFF
--- a/tsrc/cli/main.py
+++ b/tsrc/cli/main.py
@@ -10,7 +10,7 @@ import cli_ui as ui
 import colored_traceback
 
 from tsrc import __version__
-from tsrc.cli import apply_manifest, foreach, init, log, status, sync
+from tsrc.cli import apply_manifest, foreach, init, log, status, sync, manifest
 from tsrc.errors import Error
 
 ArgsList = Optional[Sequence[str]]
@@ -83,7 +83,7 @@ def main_impl(args: ArgsList = None) -> None:
 
     actions_parser = parser.add_subparsers(help="available actions", dest="action")
 
-    for module in (apply_manifest, foreach, init, log, status, sync):
+    for module in (apply_manifest, foreach, init, log, status, sync, manifest):
         module.configure_parser(actions_parser)
 
     namespace = parser.parse_args(args=args)

--- a/tsrc/cli/manifest.py
+++ b/tsrc/cli/manifest.py
@@ -38,14 +38,11 @@ def configure_parser(subparser: argparse._SubParsersAction) -> None:
 
 
 def run(args: argparse.Namespace) -> None:
-    workspace_path = args.workspace_path or Path.cwd()
     workspace = get_workspace_with_repos(args)
 
-    cfg_path = workspace_path / ".tsrc" / "config.yml"
-    clone_path = workspace_path / ".tsrc/manifest"
-    local_manifest = LocalManifest(clone_path)
-    manifest_branch = local_manifest.current_branch()
-    workspace_config = WorkspaceConfig.from_file(cfg_path)
+    cfg_path = workspace.cfg_path
+    manifest_branch = workspace.local_manifest.current_branch()
+    workspace_config = workspace.config
 
     status_collector = StatusCollector(workspace)
     repos = workspace.repos

--- a/tsrc/cli/manifest.py
+++ b/tsrc/cli/manifest.py
@@ -1,0 +1,121 @@
+""" Entry point for `tsrc manifest`. """
+import argparse
+from pathlib import Path
+
+import collections
+from typing import Dict, List, Optional, Tuple, Union
+
+import cli_ui as ui
+
+from tsrc.cli import (
+    add_groups_arg,
+    add_num_jobs_arg,
+    add_workspace_arg,
+    get_num_jobs,
+    add_repos_selection_args,
+    get_workspace_with_repos,
+    repos_from_config,
+)
+from tsrc.errors import Error
+from tsrc.local_manifest import LocalManifest
+from tsrc.workspace import Workspace
+from tsrc.workspace_config import WorkspaceConfig
+from tsrc.executor import Outcome, Task, process_items
+from tsrc.repo import Repo
+from tsrc.utils import erase_last_line
+
+
+def configure_parser(subparser: argparse._SubParsersAction) -> None:
+    parser = subparser.add_parser("manifest")
+    add_workspace_arg(parser)
+    add_repos_selection_args(parser)
+    parser.add_argument(
+        "--branch",
+        help="use this branch for the manifest",
+        dest="manifest_branch",
+    )
+    parser.set_defaults(run=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    workspace_path = args.workspace_path or Path.cwd()
+    workspace = get_workspace_with_repos(args)
+
+    cfg_path = workspace_path / ".tsrc" / "config.yml"
+    clone_path = workspace_path / ".tsrc/manifest"
+    local_manifest = LocalManifest(clone_path)
+    manifest_branch = local_manifest.current_branch()
+    workspace_config = WorkspaceConfig.from_file(cfg_path)
+
+    status_collector = StatusCollector(workspace)
+    repos = workspace.repos
+    process_items(repos, status_collector, num_jobs=1)
+
+    this_dest = None
+    this_branch = None
+    is_in_workspace = None
+    for x in repos:
+        this_dest = x.dest
+        this_branch = x.branch
+        for y in x.remotes:
+            if y.url == workspace.config.manifest_url:
+                is_in_workspace = True
+
+    ui.info_1("Manifest's URL: ", ui.purple, workspace_config.manifest_url, ui.reset)
+
+    if is_in_workspace:
+        ui.info_2("Integrated into Workspace:")
+        ui.info(ui.green, "*", ui.reset, this_dest, ui.green, this_branch, ui.reset)
+
+    if args.manifest_branch:
+        ui.info_2("Using new branch: ", ui.green, args.manifest_branch, ui.reset)
+        workspace_config.manifest_branch = args.manifest_branch
+        workspace_config.save_to_file(cfg_path)
+        ui.info_1("Workspace updated")
+        if is_in_workspace and this_branch != workspace_config.manifest_branch:
+            ui.info_2("After sync the branch will", ui.red, "differ", ui.reset)
+    else:
+        if is_in_workspace and this_branch != workspace_config.manifest_branch:
+            ui.info_2("Current branch", ui.red, "(differ):", ui.green, workspace_config.manifest_branch, ui.reset)
+        else:
+            ui.info_2("Current branch: ", ui.green, workspace_config.manifest_branch, ui.reset)
+
+
+class StatusCollector(Task[Repo]):
+    """Implement a Task to collect local git status and
+    stats w.r.t the manifest for each repo.
+    """
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.manifest = workspace.get_manifest()
+        self.statuses: CollectedStatuses = collections.OrderedDict()
+
+    def describe_item(self, item: Repo) -> str:
+        return item.dest
+
+    def describe_process_start(self, item: Repo) -> List[ui.Token]:
+        return [item.dest]
+
+    def describe_process_end(self, item: Repo) -> List[ui.Token]:
+        return []
+
+    def process(self, index: int, count: int, repo: Repo) -> Outcome:
+        # Note: Outcome is always empty here, because we
+        # use self.statuses in the main `run()` function instead
+        # of calling OutcomeCollection.print_summary()
+        full_path = self.workspace.root_path / repo.dest
+        self.info_count(index, count, repo.dest, end="\r")
+        if not full_path.exists():
+            self.statuses[repo.dest] = MissingRepo(repo.dest)
+        try:
+            git_status = get_git_status(full_path)
+            manifest_status = ManifestStatus(repo, manifest=self.manifest)
+            manifest_status.update(git_status)
+            status = Status(git=git_status, manifest=manifest_status)
+            self.statuses[repo.dest] = status
+        except Exception as e:
+            self.statuses[repo.dest] = e
+        if not self.parallel:
+            erase_last_line()
+        return Outcome.empty()

--- a/tsrc/cli/manifest.py
+++ b/tsrc/cli/manifest.py
@@ -48,31 +48,32 @@ def run(args: argparse.Namespace) -> None:
     repos = workspace.repos
     process_items(repos, status_collector, num_jobs=1)
 
-    this_dest = None
-    this_branch = None
-    is_in_workspace = None
+    this_manifest_dest = None
+    this_manifest_branch = None
+    manifest_is_in_workspace = False
     for x in repos:
-        this_dest = x.dest
-        this_branch = x.branch
         for y in x.remotes:
             if y.url == workspace.config.manifest_url:
-                is_in_workspace = True
+                manifest_is_in_workspace = True
+                this_manifest_dest = x.dest
+                this_manifest_branch = x.branch
+
 
     ui.info_1("Manifest's URL: ", ui.purple, workspace_config.manifest_url, ui.reset)
 
-    if is_in_workspace:
+    if manifest_is_in_workspace:
         ui.info_2("Integrated into Workspace:")
-        ui.info(ui.green, "*", ui.reset, this_dest, ui.green, this_branch, ui.reset)
+        ui.info(ui.green, "*", ui.reset, this_manifest_dest, ui.green, this_manifest_branch, ui.reset)
 
     if args.manifest_branch:
         ui.info_2("Using new branch: ", ui.green, args.manifest_branch, ui.reset)
         workspace_config.manifest_branch = args.manifest_branch
         workspace_config.save_to_file(cfg_path)
         ui.info_1("Workspace updated")
-        if is_in_workspace and this_branch != workspace_config.manifest_branch:
+        if manifest_is_in_workspace and this_manifest_branch != workspace_config.manifest_branch:
             ui.info_2("After sync the branch will", ui.red, "differ", ui.reset)
     else:
-        if is_in_workspace and this_branch != workspace_config.manifest_branch:
+        if manifest_is_in_workspace and this_manifest_branch != workspace_config.manifest_branch:
             ui.info_2("Current branch", ui.red, "(differ):", ui.green, workspace_config.manifest_branch, ui.reset)
         else:
             ui.info_2("Current branch: ", ui.green, workspace_config.manifest_branch, ui.reset)

--- a/tsrc/cli/status.py
+++ b/tsrc/cli/status.py
@@ -43,10 +43,30 @@ def run(args: argparse.Namespace) -> None:
     erase_last_line()
     ui.info_2("Workspace status:")
     statuses = status_collector.statuses
+
+    """detect same Manifest's repository in the workspace repositories"""
+    """and also check if there is missing upstream"""
+    static_manifest_manifest_dest = None    # "static" as it cannot be changed, "manifest_manifest" = Manifest repo in Manifest.yml; this may not exist but if it does, it will be the 'dest'intion == "direcory_name"
+    static_manifest_manifest_branch = None  # "static" as it cannot be changed, "manifest_manifest" = Manifest repo in Manifest.yml; this may not exist, but if it does, it will be the (git) 'branch'
+    workspace_manifest_repo_branch = None   # Workspace's > Manifest_repo's > branch
+    for x in repos:
+        this_dest = x.dest
+        this_branch = x.branch
+        for y in x.remotes:
+            if y.url == workspace.config.manifest_url:
+                static_manifest_manifest_dest = this_dest
+                workspace_manifest_repo_branch = workspace.local_manifest.current_branch()
+                static_manifest_manifest_branch = this_branch
+
     max_dest = max(len(x) for x in statuses.keys())
     for dest, status in statuses.items():
         message = [ui.green, "*", ui.reset, dest.ljust(max_dest)]
         message += describe_status(status)
+        if dest == static_manifest_manifest_dest:
+            message += [ui.purple, "<---", "MANIFEST:"]
+            message += [ui.green, static_manifest_manifest_branch]
+            if workspace.config.manifest_branch != static_manifest_manifest_branch:
+                message += [ui.reset, "~~~>", ui.green, workspace.config.manifest_branch]
         ui.info(*message)
 
 

--- a/tsrc/cli/status.py
+++ b/tsrc/cli/status.py
@@ -57,6 +57,7 @@ class ManifestStatus:
         self.repo = repo
         self.manifest = manifest
         self.incorrect_branch: Optional[Tuple[str, str]] = None
+        self.missing_upstream = None
 
     def update(self, git_status: GitStatus) -> None:
         """Set self.incorrect_branch if the local git status
@@ -66,6 +67,7 @@ class ManifestStatus:
         actual_branch = git_status.branch
         if actual_branch and actual_branch != expected_branch:
             self.incorrect_branch = (actual_branch, expected_branch)
+        self.missing_upstream = not git_status.upstreamed
 
     def describe(self) -> List[ui.Token]:
         """Return a list of tokens suitable for ui.info()`."""
@@ -74,6 +76,8 @@ class ManifestStatus:
         if incorrect_branch:
             actual, expected = incorrect_branch
             res += [ui.red, "(expected: " + expected + ")"]
+        if self.missing_upstream:
+            res += [ui.red, "(missing upstream)"]
         return res
 
 

--- a/tsrc/git.py
+++ b/tsrc/git.py
@@ -77,6 +77,7 @@ class GitStatus:
         self.tag: Optional[str] = None
         self.branch: Optional[str] = None
         self.sha1: Optional[str] = None
+        self.upstreamed = False
 
     def update(self) -> None:
         # Try and gather as many information about the git repository as
@@ -90,6 +91,7 @@ class GitStatus:
         self.update_tag()
         self.update_remote_status()
         self.update_worktree_status()
+        self.update_upstreamed()
 
     def update_sha1(self) -> None:
         self.sha1 = get_sha1(self.working_path, short=True)
@@ -135,6 +137,11 @@ class GitStatus:
             if line.startswith("A "):
                 self.added += 1
                 self.dirty = True
+
+    def update_upstreamed(self) -> None:
+        rc, _ = run_git_captured(self.working_path, "config", "--get", f"branch.{self.branch}.remote", check=False)
+        if rc == 0:
+            self.upstreamed = True
 
     def describe(self) -> List[ui.Token]:
         """Return a list of tokens suitable for ui.info."""

--- a/tsrc/status_endpoint.py
+++ b/tsrc/status_endpoint.py
@@ -1,55 +1,15 @@
-""" Entry point for tsrc status """
-
-import argparse
 import collections
 from typing import Dict, List, Optional, Tuple, Union
 
 import cli_ui as ui
 
-from tsrc.cli import (
-    add_num_jobs_arg,
-    add_repos_selection_args,
-    add_workspace_arg,
-    get_num_jobs,
-    get_workspace_with_repos,
-)
 from tsrc.errors import MissingRepo
-from tsrc.executor import Outcome, Task, process_items
+from tsrc.executor import Outcome, Task
 from tsrc.git import GitStatus, get_git_status
 from tsrc.manifest import Manifest
 from tsrc.repo import Repo
 from tsrc.utils import erase_last_line
 from tsrc.workspace import Workspace
-from tsrc.status_endpoint import StatusCollector, ManifestStatus, describe_status
-
-
-def configure_parser(subparser: argparse._SubParsersAction) -> None:
-    parser = subparser.add_parser("status")
-    add_workspace_arg(parser)
-    add_repos_selection_args(parser)
-    add_num_jobs_arg(parser)
-    parser.set_defaults(run=run)
-
-
-def run(args: argparse.Namespace) -> None:
-    workspace = get_workspace_with_repos(args)
-    status_collector = StatusCollector(workspace)
-    repos = workspace.repos
-    if not repos:
-        ui.info_2("Workspace is empty")
-        return
-    ui.info_1(f"Collecting statuses of {len(repos)} repo(s)")
-    num_jobs = get_num_jobs(args)
-    process_items(repos, status_collector, num_jobs=num_jobs)
-    erase_last_line()
-    ui.info_2("Workspace status:")
-    statuses = status_collector.statuses
-    max_dest = max(len(x) for x in statuses.keys())
-    for dest, status in statuses.items():
-        message = [ui.green, "*", ui.reset, dest.ljust(max_dest)]
-        message += describe_status(status)
-        ui.info(*message)
-
 
 class ManifestStatus:
     """Represent the status of a repo w.r.t the manifest."""
@@ -89,22 +49,6 @@ class Status:
         self.git = git
         self.manifest = manifest
 
-
-StatusOrError = Union[Status, Exception]
-CollectedStatuses = Dict[str, StatusOrError]
-
-
-def describe_status(status: StatusOrError) -> List[ui.Token]:
-    """Return a list of tokens suitable for ui.info()."""
-    if isinstance(status, MissingRepo):
-        return [ui.red, "error: missing repo"]
-    if isinstance(status, Exception):
-        return [ui.red, "error: ", status]
-    git_status = status.git.describe()
-    manifest_status = status.manifest.describe()
-    return git_status + manifest_status
-
-
 class StatusCollector(Task[Repo]):
     """Implement a Task to collect local git status and
     stats w.r.t the manifest for each repo.
@@ -143,3 +87,19 @@ class StatusCollector(Task[Repo]):
         if not self.parallel:
             erase_last_line()
         return Outcome.empty()
+
+
+
+StatusOrError = Union[Status, Exception]
+# CollectedStatuses = Dict[str, StatusOrError]
+
+
+def describe_status(status: StatusOrError) -> List[ui.Token]:
+    """Return a list of tokens suitable for ui.info()."""
+    if isinstance(status, MissingRepo):
+        return [ui.red, "error: missing repo"]
+    if isinstance(status, Exception):
+        return [ui.red, "error: ", status]
+    git_status = status.git.describe()
+    manifest_status = status.manifest.describe()
+    return git_status + manifest_status


### PR DESCRIPTION
use: `tsrc manifest --branch <new_branch>` to setup new branch for Manifest. 

`tsrc sync` is required after that.

 use without `--branch` option to see extended information