### PR TITLE
fix: smooth transition from Workspaces initialized by older versions

### DIFF
--- a/tsrc/cli/init.py
+++ b/tsrc/cli/init.py
@@ -1,4 +1,5 @@
 """ Entry point for `tsrc init`. """
+
 import argparse
 from pathlib import Path
 

--- a/tsrc/groups.py
+++ b/tsrc/groups.py
@@ -1,4 +1,5 @@
 """ Support for groups of elements """
+
 # Note that groups are allowed to include other groups.
 
 from typing import Any, Dict, Generic, List, Optional, TypeVar

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -1,4 +1,5 @@
 """ Repo objects. """
+
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/tsrc/workspace_config.py
+++ b/tsrc/workspace_config.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -28,6 +29,12 @@ class WorkspaceConfig:
     def from_file(cls, cfg_path: Path) -> "WorkspaceConfig":
         yaml = ruamel.yaml.YAML(typ="rt")
         parsed = yaml.load(cfg_path.read_text())
+        if not parsed.get("manifest_branch_0"):
+            """compatibility fix for older version.
+            usefull when transitioning with Workspace initialized
+            by older version"""
+            parsed["manifest_branch_0"] = parsed.get("manifest_branch")
+            parsed = OrderedDict(sorted(parsed.items()))
         return cls(**parsed)
 
     def save_to_file(self, cfg_path: Path) -> None:


### PR DESCRIPTION
Ensure backward compatibility from Workspace initialized by older versions.