### PR TITLE
fix: status display of DM and FM on filtering

### DIFF
--- a/tsrc/cli/status.py
+++ b/tsrc/cli/status.py
@@ -79,6 +79,7 @@ def run(args: argparse.Namespace) -> None:
         workspace,
         gtf,
         manifest_marker=not args.no_manifest_marker,
+        future_manifest=not args.no_future_manifest,
     )
 
     status_header = StatusHeader(
@@ -105,11 +106,10 @@ def run(args: argparse.Namespace) -> None:
     _, dm = get_deep_manifest_pcsrepo(repos, workspace.config.manifest_url)
 
     sm = None
-    if args.no_deep_manifest is False:
-        sm = is_manifest_in_workspace(workspace, repos)
     if args.no_deep_manifest is True:
-        print("DEBUG ::--no-dm::")
         dm = None
+    else:
+        sm = is_manifest_in_workspace(workspace, repos)
 
     if sm:
         # TODO: unfortunately this is not enough. there is possibility that
@@ -122,19 +122,10 @@ def run(args: argparse.Namespace) -> None:
 
     statuses = status_collector.statuses
 
-    # TODO: apprise should be set by input parameter
-    #    wrs = WorkspaceReposSummary(
-    #        workspace,
-    #        statuses,
-    #        dm,
-    #        args.groups,
-    #        apprise=True,
-    #    )
     wrs.ready_data(
         statuses,
         dm,
         apprise=not args.no_future_manifest,
-        # apprise=False,
     )
     wrs.summary()
     try:

--- a/tsrc/local_future_manifest.py
+++ b/tsrc/local_future_manifest.py
@@ -1,10 +1,15 @@
 """
 Local Future Manifest
 
-Obtains information from already checkouted
-(thus 'Local')
-Future Manifest in:
+Obtains information about Future Manifest
+by init or update Manifest repository
+to *local* directory.
+
+Local Future Manifest will be in:
 root_path / ".tsrc" / "future_manifest"
+
+This way we can see how Workspace will transform
+after the 'sync'.
 """
 
 from typing import Dict, Tuple, Union


### PR DESCRIPTION
fix:

- do not display DM leftovers when '--no-dm' is provided to status
- do not display FM leftovers when '--no-fm' is provided to status
- test for '--no-fm' on FM leftovers

added:

- test for '--no-dm' on DM leftovers