### PR TITLE
new feature: tmp bare repo: show position for DM|FM if SHA1

### DIFF
--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -263,10 +263,26 @@ def resolve_repos_without_workspace(
     return repos
 
 
+def is_match_repo_dest_on_inc_excl(
+    gac: GroupsAndConstraints,
+    i_r_d: str,
+) -> bool:
+    if (
+        (gac.include_regex and re.search(gac.include_regex, i_r_d))  # noqa: W503
+        or not gac.include_regex  # noqa: W503
+    ) and (
+        (gac.exclude_regex and not re.search(gac.exclude_regex, i_r_d))  # noqa: W503
+        or not gac.exclude_regex  # noqa: W503
+    ):
+        return True
+    return False
+
+
 def resolve_repos_apply_constraints(
     repos: List[Repo],
     gac: GroupsAndConstraints,
 ) -> List[Repo]:
+    # NOTE: code duplication, see Fn above, and above above
     """
     Use just constraints on Repos in GroupAndConstraints class
     to filter Repos. Consider:

--- a/tsrc/cli/manifest.py
+++ b/tsrc/cli/manifest.py
@@ -157,7 +157,8 @@ def run(args: argparse.Namespace) -> None:
         wrs.ready_data(
             statuses,
         )
-        wrs.separate_leftover_statuses(workspace.repos)
+        wrs.separate_statuses(workspace.repos)
+        wrs.calculate_fields_len()
 
         # only calculate summary when there are some Workspace repos
         if workspace.repos:

--- a/tsrc/dump_manifest_args_data.py
+++ b/tsrc/dump_manifest_args_data.py
@@ -21,6 +21,19 @@ class UpdateSourceEnum(Enum):
     DEEP_MANIFEST = 2
 
 
+@dataclass
+class ManifestDataOptions:
+    sha1_only: bool = False
+    skip_manifest: bool = False
+    only_manifest: bool = False
+    ignore_groups: bool = False  # not implemented
+
+    def clean(self) -> None:
+        for i in dir(self):
+            if isinstance(getattr(self, i), bool) is True:
+                setattr(self, i, False)
+
+
 class FinalOutputModeFlag(Flag):
     NONE = 0
     PREVIEW = 1
@@ -75,6 +88,9 @@ class DumpManifestOperationDetails:
     update_source = UpdateSourceEnum.NONE
     update_source_path: Optional[Path] = None
 
+    # OPTIONS applied when processing Manifest (optional to change, using defaults)
+    manifest_data_options = ManifestDataOptions()
+
     # FINAL OUTPUT MODE (must be determined)
     final_output_mode: List[FinalOutputModeFlag] = field(default_factory=list)
     final_output_path_list = FinalOutputAllPaths()
@@ -96,6 +112,7 @@ class DumpManifestOperationDetails:
     def clean(self) -> None:
         self.final_output_path_list.clean_all_paths()
         self.final_output_mode = []
+        self.manifest_data_options.clean()
 
     # ----------
     # 'get_path' - section

--- a/tsrc/dump_manifest_args_source_mode.py
+++ b/tsrc/dump_manifest_args_source_mode.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 from tsrc.cli import get_workspace_with_repos
 from tsrc.dump_manifest_args_data import DumpManifestOperationDetails, SourceModeEnum
+from tsrc.errors import Error
 
 
 class SourceMode:
@@ -24,6 +25,9 @@ class SourceMode:
         self._decide_source_mode()
 
         self._get_workspace_if_needed()
+
+        if not self.dmod.workspace:
+            self._get_workspace_optionally()
 
         return self.dmod, self.args
 
@@ -55,3 +59,16 @@ class SourceMode:
         ):
             # it will throw Error if there is no Workspace
             self.dmod.workspace = get_workspace_with_repos(self.args)
+
+    def _get_workspace_optionally(self) -> None:
+        # do not throw and Error if Workspace is not found
+        if self.args.raw_dump_path and (
+            self.args.skip_manifest is True or self.args.only_manifest is True
+        ):
+            try:
+                self.dmod.workspace = get_workspace_with_repos(self.args)
+            except Exception as e:
+                if isinstance(e, Error):
+                    pass
+                else:
+                    raise e

--- a/tsrc/dump_manifest_args_update_source.py
+++ b/tsrc/dump_manifest_args_update_source.py
@@ -24,7 +24,7 @@ class UpdateSource:
 
     def get_update_source_and_path(self) -> DumpManifestOperationDetails:
 
-        self._possible_mistmatch_on_dump_path()
+        self._possible_mismatch_on_dump_path()
 
         self._allow_only_1_update_on_a_time()
 
@@ -47,7 +47,7 @@ class UpdateSource:
 
         return self.dmod
 
-    def _possible_mistmatch_on_dump_path(self) -> None:
+    def _possible_mismatch_on_dump_path(self) -> None:
         # if we want to update Workspace Manifest with data from RAW dump
         if (
             self.args.raw_dump_path

--- a/tsrc/dump_manifest_helper.py
+++ b/tsrc/dump_manifest_helper.py
@@ -54,6 +54,7 @@ class MRISHelpers:
         return ManifestRepoItem(
             branch=repo.branch,
             tag=repo.tag,
+            # sha1=repo.sha1_full,
             sha1=repo.sha1,
             ignore_submodules=repo.ignore_submodules,
             remotes=repo.remotes,
@@ -80,7 +81,7 @@ class MRISHelpers:
             return ManifestRepoItem(
                 branch=status.git.branch,
                 tag=status.git.tag,
-                sha1=status.git.sha1,
+                sha1=status.git.sha1_full,
                 empty=status.git.empty,
                 ignore_submodules=w_repo.ignore_submodules,
                 remotes=w_repo.remotes,

--- a/tsrc/git_remote.py
+++ b/tsrc/git_remote.py
@@ -23,7 +23,7 @@ class GitRemote:
         self.working_path = working_path
         self.branch = cur_branch
         self.remotes: List[Remote] = []
-        self.upstreamed = False  # only refers to current branch
+        self.upstreamed = False  # only related to current branch
 
     def update(self) -> None:
         self.update_remotes()
@@ -48,8 +48,7 @@ class GitRemote:
             if use_branch.startswith("heads/") is True:
                 use_branch = use_branch[6:]
         else:
-            self.upstreamed = False
-            # skip git check if upstreamed when there is no branch
+            # skip check if upstreamed when there is no branch
             return
 
         rc, _ = run_git_captured(

--- a/tsrc/groups_and_constraints_data.py
+++ b/tsrc/groups_and_constraints_data.py
@@ -15,13 +15,14 @@ from typing import List, Optional
 class GroupsAndConstraints:
     groups: Optional[List[str]] = None  # just what was provided via cmd
     # not to be mistaken with Group class
-    singular_remote: str = ""
+    singular_remote: str = ""  # NOTE possibly unused by now
     include_regex: str = ""
     exclude_regex: str = ""
 
 
 def get_group_and_constraints_data(args: argparse.Namespace) -> GroupsAndConstraints:
 
+    # NOTE: does not obtains 'singular_remote'
     groups: Optional[List[str]] = None
     if args.groups:
         groups = args.groups

--- a/tsrc/local_tmp_bare_repos.py
+++ b/tsrc/local_tmp_bare_repos.py
@@ -1,0 +1,143 @@
+"""
+# local_tmp_bare_repos
+
+## conditions for use
+
+This is only usefull when these 3 conditions are met:
+
+1st: Reasonable use is only for:
+* Deep Manifest
+* Future Manifest
+
+2nd: SHA1 must be set for such Repo
+
+3rd: remote must be set and reachable
+
+## What it does:
+
+Bare Git repository should be created
+to some temporary location (under '.tsrc')
+or updated to required commit SHA1.
+
+current SHA1 is then checked with remote to
+count possition ahead/behind.
+"""
+
+import hashlib
+from pathlib import Path
+from typing import List, Optional
+
+from tsrc.cloner import BareCloner
+
+# import cli_ui as ui
+from tsrc.errors import LoadManifestSchemaError
+from tsrc.executor import process_items
+from tsrc.groups_to_find import GroupsToFind
+from tsrc.local_manifest import LocalManifest
+from tsrc.manifest_common import ManifestGetRepos
+from tsrc.manifest_common_data import ManifestsTypeOfData
+from tsrc.pcs_repo import PCSRepo
+from tsrc.repo import Repo
+from tsrc.utils import erase_last_line
+from tsrc.workspace import Workspace
+
+
+def prepare_tmp_bare_dm_repos(
+    workspace: Workspace,
+    dm: PCSRepo,
+    gtf: GroupsToFind,
+    num_jobs: int,
+) -> List[Repo]:
+    """
+    Take care of Deep Manifest's Repos to repsect Groups
+    """
+
+    # get Repos from Deep Manifest (considering Groups)
+    dm_path = workspace.root_path / dm.dest
+    ldm = LocalManifest(dm_path)
+    try:
+        ldmm = ldm.get_manifest_safe_mode(ManifestsTypeOfData.DEEP)
+    # except LoadManifestSchemaError as lmse:
+    except LoadManifestSchemaError:
+        # ui.warning(lmse)
+        return []
+
+    # get repos that match Groups provided
+    mgr = ManifestGetRepos(workspace, ldmm, True, workspace.config.clone_all_repos)
+    repos, _, gtf = mgr.by_groups(gtf, must_find_all_groups=False)
+
+    c_repos: List[Repo] = ready_tmp_bare_repos(
+        workspace, ManifestsTypeOfData.DEEP, repos
+    )
+
+    return c_repos
+
+
+def process_bare_repos(
+    workspace: Workspace, c_repos: List[Repo], num_jobs: int
+) -> List[Repo]:
+
+    # TODO: possibly add 'config' -> 'remote_name=self.config.singular_remote'
+    bare_cloner = BareCloner(workspace.root_path)
+
+    process_items(c_repos, bare_cloner, num_jobs=num_jobs)
+    erase_last_line()
+
+    return c_repos
+
+
+def ready_tmp_bare_repos(
+    workspace: Workspace, mtod: ManifestsTypeOfData, repos: List[Repo]
+) -> List[Repo]:
+
+    # create parent directory if it does not exists
+    if repos:
+        mtod_path: str
+        if mtod == ManifestsTypeOfData.DEEP:
+            mtod_path = ".tmp_dm_repos"
+        elif mtod == ManifestsTypeOfData.FUTURE:
+            mtod_path = ".tmp_fm_repos"
+        else:
+            return []  # do not continue
+
+        tmp_dir = workspace.root_path / ".tsrc" / mtod_path
+        if not tmp_dir.is_dir():
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    # create Repo's directory if it does not exists when there is SHA1
+    c_repos: List[Repo] = []  # consider repos (to get the possition)
+    for repo in repos:
+        if repo.sha1 and repo.remotes:
+            h = hashlib.sha1(repo.clone_url.encode())
+            # create dirname with hash of URL
+            this_dir = h.hexdigest()[:13] + "_" + repo.dest
+            repo_dir = tmp_dir / this_dir
+
+            # check if there is Repo in Workspace
+            possible_w_path = workspace.root_path / repo.dest
+            possible_w_path_git = possible_w_path / ".git"
+            bare_clone_path: Optional[Path] = None
+            if possible_w_path_git.is_dir():
+                bare_clone_path = possible_w_path
+
+            # add Repo that can be processed by 'process_items'
+            c_repos.append(
+                Repo(
+                    dest=str(repo_dir),
+                    remotes=repo.remotes,
+                    branch=repo.branch,
+                    keep_branch=repo.keep_branch,
+                    is_default_branch=repo.is_default_branch,
+                    orig_branch=repo.orig_branch,
+                    sha1=repo.sha1,
+                    tag=repo.tag,
+                    shallow=False,
+                    is_bare=True,
+                    _bare_clone_path=bare_clone_path,
+                    _bare_clone_mtod=mtod,
+                    _bare_clone_orig_dest=repo.dest,
+                    _bare_clone_is_ok=repo._bare_clone_is_ok,
+                )
+            )
+
+    return c_repos

--- a/tsrc/status_header.py
+++ b/tsrc/status_header.py
@@ -96,28 +96,44 @@ class StatusHeader:
                 else:
                     self._header_manifest_branch(self.branch, self.branch_0)
 
-    def report_collecting(self, c_all: int) -> None:
-        """report about how much Repos will be processed
-        in order to obatain its Status"""
-        c_w_repos = len(self.workspace.repos)
-        c_w_repos_s = self._is_plural(c_w_repos, "s")
-        c_l_repos = c_all - c_w_repos
-        c_l_repos_s = self._is_plural(c_l_repos, "s")
-        c_all_es = self._is_plural(c_w_repos + c_l_repos, "es")
+    def report_collecting(self, cw: int, cl: int = 0, cb: int = 0) -> None:
+        """
+        Properly display counters of Repos of various kind,
+        that will be processed together, like:
+        * 'cw' - count of Workspace Repos
+        * 'cl' - count of leftovers Repo (both DM and FM)
+        * 'cb' - count of temporary Bare Repos (both DM and FM)
+        """
+        cw_pl = self._is_plural(cw, "s")
+        cl_pl = self._is_plural(cl, "s")
+        cb_pl = self._is_plural(cb, "s")
+        str_cw = f"{cw} workspace repo{cw_pl}"
+        str_cl = f"{cl} leftovers repo{cl_pl}"
+        str_cb = f"{cb} tmp bare repo{cb_pl}"
+        start_pl = ""
+        if cw > 0:
+            start_pl = self._is_plural(cw, "es")
+        elif cl > 0:
+            start_pl = self._is_plural(cl, "es")
+        else:
+            start_pl = self._is_plural(cb, "es")
 
-        if c_w_repos == c_all:  # no leftover repo(s)
-            ui.info_1(
-                f"Collecting status{c_all_es} of {c_w_repos} workspace repo{c_w_repos_s}"
-            )
-        else:  # with leftover repo(s)
-            if c_w_repos == 0:  # without workspace repo(s)
-                ui.info_1(
-                    f"Collecting status{c_all_es} of {c_l_repos} leftover repo{c_l_repos_s}"  # noqa: E501
-                )
-            else:  # combined workspace and leftover repo(s)
-                ui.info_1(
-                    f"Collecting status{c_all_es} of {c_w_repos} workspace repo{c_w_repos_s} + {c_l_repos} leftover repo{c_l_repos_s}"  # noqa: E501
-                )
+        str_out = ""
+        if cw > 0 or cl > 0 or cb > 0:
+            str_out = f"Collecting status{start_pl} of "
+        if cw > 0:
+            str_out += str_cw
+            if cl > 0 or cb > 0:
+                str_out += " + "
+        if cl > 0:
+            str_out += str_cl
+            if cb > 0:
+                str_out += " + "
+        if cb > 0:
+            str_out += str_cb
+
+        if str_out:
+            ui.info_1(str_out)
 
     """ internal functions """
 

--- a/tsrc/test/cli/test_display_bare_repos.py
+++ b/tsrc/test/cli/test_display_bare_repos.py
@@ -1,0 +1,522 @@
+"""
+Test 'status' display with Bare Repo postion
+
+This is in fact extension to DM FM MM test display
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+# import pytest
+import ruamel.yaml
+from cli_ui.tests import MessageRecorder
+
+from tsrc.git import run_git, run_git_captured
+from tsrc.test.helpers.cli import CLI
+from tsrc.test.helpers.git_server import GitServer
+from tsrc.test.helpers.message_recorder_ext import MessageRecorderExt
+from tsrc.workspace_config import WorkspaceConfig
+
+
+def test_create_new_assembly_chain_by_tag_and_sha1(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Test when Bare Repo's have Tag and SHA1,
+    while it:
+    * does not point to the same commit
+    * does point to the same commit
+
+    and how does it show in 'status' command
+    """
+    # 1st: create repositories representing project
+    git_server.add_repo("frontend-proj")
+    git_server.push_file("frontend-proj", "frontend-proj.txt")
+    git_server.add_repo("backend-proj")
+    git_server.push_file("backend-proj", "backend-proj.txt")
+    git_server.add_repo("extra-lib")
+    git_server.push_file("extra-lib", "extra-lib.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add there a Manifest Repo
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init Workspace
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: introduce some changes to various repositories
+    #   simulating development process
+    fp = Path(workspace_path / "frontend-proj")
+    Path(fp / "latest-changes.txt").touch()
+    run_git(fp, "add", "latest-changes.txt")
+    run_git(fp, "commit", "-m", "adding latest changes")
+    run_git(fp, "push", "origin", "master")
+
+    bp = Path(workspace_path / "backend-proj")
+    Path(bp / "latest-changes.txt").touch()
+    run_git(bp, "add", "latest-changes.txt")
+    run_git(bp, "commit", "-m", "adding latest changes")
+    run_git(bp, "push", "origin", "master")
+
+    el = Path(workspace_path / "extra-lib")
+    Path(el / "latest-changes.txt").touch()
+    run_git(el, "add", "latest-changes.txt")
+    run_git(el, "tag", "-a", "ver_x", "-m", "version x")
+    _, sha1_of_tag = run_git_captured(el, "rev-parse", "HEAD", check=False)
+    run_git(el, "commit", "-m", "adding latest changes")
+    run_git(el, "push", "origin", "master")
+
+    # 5th: consider reaching some consistant state, thus
+    #   start to create new assembly chain
+    #   by checking out new branch on Manifest
+    mp = Path(workspace_path / "manifest")
+    run_git(mp, "checkout", "-b", "ac_1.0")
+
+    # 6th: create Manifest with SHA1 marks while skipping Manifest Repo
+    tsrc_cli.run("dump-manifest", "--sha1-only", "--update", "--skip-manifest")
+
+    # 7th: let us update Manifest, but only with its branch (no SHA1)
+    tsrc_cli.run("dump-manifest", "--update", "--only-manifest", "--force")
+
+    tsrc_cli.run("status")
+
+    # 8th: commit and push such Manifest to remote
+    run_git(mp, "add", "manifest.yml")
+    run_git(mp, "commit", "-m", "new assembly chain of version 1.0")
+    run_git(mp, "push", "-u", "origin", "ac_1.0")
+
+    """
+    We have successfully created assembly chain of version 1.0
+
+    Let us now continue with development towards another
+    assembly chain
+    """
+
+    # 9th: adding more changes to create another assembly chain
+    Path(fp / "new_files.txt").touch()
+    run_git(fp, "add", "new_files.txt")
+    run_git(fp, "commit", "-m", "adding new changes")
+    run_git(fp, "push", "origin", "master")
+
+    Path(bp / "new_files.txt").touch()
+    run_git(bp, "add", "new_files.txt")
+    run_git(bp, "commit", "-m", "adding new changes")
+    run_git(bp, "push", "origin", "master")
+
+    Path(el / "new_files.txt").touch()
+    run_git(el, "add", "new_files.txt")
+    run_git(el, "commit", "-m", "adding new changes")
+    run_git(el, "push", "origin", "master")
+
+    # 10th: dumping and updating Manifest
+    tsrc_cli.run(
+        "dump-manifest", "--raw", ".", "--sha1-only", "--update", "--skip-manifest"
+    )
+
+    # checkout new branch for Manifest in order to dump it to Manifest later
+    run_git(mp, "checkout", "-b", "ac_1.1")
+    tsrc_cli.run("dump-manifest", "--update", "--only-manifest", "--force")
+    run_git(mp, "add", "manifest.yml")
+    run_git(mp, "commit", "-m", "new assembly chain of version 1.1")
+    run_git(mp, "push", "-u", "origin", "refs/heads/ac_1.1")
+
+    # 11th: change branch for next Manifest
+    tsrc_cli.run("manifest", "--branch", "ac_1.1")
+
+    """
+    We are now ready to sync 'ac_1.1' version
+    """
+
+    # 12th: sync the new version
+    tsrc_cli.run("sync")
+
+    # 13th: we want to return back to older assembly chain 'ac_1.0'
+    tsrc_cli.run("manifest", "--branch", "ac_1.0")
+
+    # 14th: sync the older version
+    tsrc_cli.run("sync")
+
+    _, wrong_sha1_of_tag = run_git_captured(el, "rev-parse", "HEAD", check=False)
+    ad_hoc_update_sha1_from_manifest(mp / "manifest.yml", wrong_sha1_of_tag)
+    ad_hoc_add_tag_to_manifest(mp / "manifest.yml", "ver_x")
+
+    # 15th: we can see here wrong SHA1 for branch+Tag
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    short_wrong_sha1 = wrong_sha1_of_tag[:7]
+    assert message_recorder.find(
+        rf"\* extra-lib     \[ master on ver_x !! {short_wrong_sha1} \]  master .1 commit"
+    )
+
+    # 16th: and now there is correct brach+Tag+SHA1
+    ad_hoc_update_sha1_from_manifest(mp / "manifest.yml", sha1_of_tag)
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(
+        r"\* extra-lib     \[ master on ver_x .1 commit \]  master .1 commit"
+    )
+
+
+def test_create_new_assembly_chain_by_sha1(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder_ext: MessageRecorderExt,
+) -> None:
+    """
+    test various types of temporary bare repos
+    displays like:
+    * X commits behind
+    * missing remote
+    * wrong commit
+
+    Scenario (mostly taken from examle:USE-CASE 2):
+
+    * 1st: create repositories representing project
+    * 2nd: add there a Manifest Repo
+    * 3rd: init Workspace
+    * 4th: introduce some changes to various repositories
+       simulating development process
+    * 5th: consider reaching some consistant state, thus
+       start to create new assembly chain
+       by checking out new branch on Manifest
+    * 6th: create Manifest with SHA1 marks while skipping Manifest Repo
+    * 7th: let us update Manifest, but only with its branch (no SHA1)
+    * 8th: commit and push such Manifest to remote
+
+    We have successfully created assembly chain of version 1.0
+
+    Let us now continue with development towards another
+    assembly chain
+
+    * 9th: adding more changes to create another assembly chain
+    * 10th: dumping and updating Manifest
+    * 11th: change branch for next Manifest
+
+    We are now ready to sync 'ac_1.1' version
+
+    * 12th: sync the new version
+    * 13th: we want to return back to older assembly chain 'ac_1.0'
+    * 14th: sync the older version
+    * 15th: let us see how it end-up when showing the status
+
+    Now we can see, that all non-Manifest Repositories are
+    1 commit behind. That is exactly right as we have synced
+    to previous assembly chain. It was on the same branch,
+    yet the commit SHA1 was earlier in time
+    """
+    message_recorder = message_recorder_ext
+
+    # 1st: create repositories representing project
+    git_server.add_repo("frontend-proj")
+    git_server.push_file("frontend-proj", "frontend-proj.txt")
+    git_server.add_repo("backend-proj")
+    git_server.push_file("backend-proj", "backend-proj.txt")
+    git_server.add_repo("extra-lib")
+    git_server.push_file("extra-lib", "extra-lib.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add there a Manifest Repo
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init Workspace
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: introduce some changes to various repositories
+    #   simulating development process
+    fp = Path(workspace_path / "frontend-proj")
+    Path(fp / "latest-changes.txt").touch()
+    run_git(fp, "add", "latest-changes.txt")
+    run_git(fp, "commit", "-m", "adding latest changes")
+    run_git(fp, "push", "origin", "master")
+
+    bp = Path(workspace_path / "backend-proj")
+    Path(bp / "latest-changes.txt").touch()
+    run_git(bp, "add", "latest-changes.txt")
+    run_git(bp, "commit", "-m", "adding latest changes")
+    run_git(bp, "push", "origin", "master")
+
+    el = Path(workspace_path / "extra-lib")
+    Path(el / "latest-changes.txt").touch()
+    run_git(el, "add", "latest-changes.txt")
+    run_git(el, "commit", "-m", "adding latest changes")
+    run_git(el, "push", "origin", "master")
+
+    # 5th: consider reaching some consistant state, thus
+    #   start to create new assembly chain
+    #   by checking out new branch on Manifest
+    mp = Path(workspace_path / "manifest")
+    run_git(mp, "checkout", "-b", "ac_1.0")
+
+    # 6th: create Manifest with SHA1 marks while skipping Manifest Repo
+    tsrc_cli.run("dump-manifest", "--sha1-only", "--update", "--skip-manifest")
+
+    # 7th: let us update Manifest, but only with its branch (no SHA1)
+    tsrc_cli.run("dump-manifest", "--update", "--only-manifest", "--force")
+
+    # 8th: commit and push such Manifest to remote
+    run_git(mp, "add", "manifest.yml")
+    run_git(mp, "commit", "-m", "new assembly chain of version 1.0")
+    run_git(mp, "push", "-u", "origin", "ac_1.0")
+
+    """
+    We have successfully created assembly chain of version 1.0
+
+    Let us now continue with development towards another
+    assembly chain
+    """
+
+    # 9th: adding more changes to create another assembly chain
+    Path(fp / "new_files.txt").touch()
+    run_git(fp, "add", "new_files.txt")
+    run_git(fp, "commit", "-m", "adding new changes")
+    run_git(fp, "push", "origin", "master")
+
+    Path(bp / "new_files.txt").touch()
+    run_git(bp, "add", "new_files.txt")
+    run_git(bp, "commit", "-m", "adding new changes")
+    run_git(bp, "push", "origin", "master")
+
+    Path(el / "new_files.txt").touch()
+    run_git(el, "add", "new_files.txt")
+    run_git(el, "commit", "-m", "adding new changes")
+    run_git(el, "push", "origin", "master")
+
+    # to test how it will handle repos with located in sub-dir
+    sub1_path = Path("inside")
+    os.makedirs(sub1_path)
+    os.chdir(sub1_path)
+    sub1_1_path = Path("repo_inside")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full1_path, "add", "in_repo.txt")
+    run_git(full1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # we need to add remote as well
+    sub_1_1_url = git_server.get_url(str(sub1_1_path))
+    sub_1_1_url_path = Path(git_server.url_to_local_path(sub_1_1_url))
+    sub_1_1_url_path.mkdir()
+    run_git(sub_1_1_url_path, "init", "--bare")
+    run_git(full1_path, "remote", "add", "origin", sub_1_1_url)
+    run_git(full1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    # 10th: dumping and updating Manifest
+    tsrc_cli.run(
+        "dump-manifest", "--raw", ".", "--sha1-only", "--update", "--skip-manifest"
+    )
+
+    # checkout new branch for Manifest in order to dump it to Manifest later
+    run_git(mp, "checkout", "-b", "ac_1.1")
+    tsrc_cli.run("dump-manifest", "--update", "--only-manifest", "--force")
+    run_git(mp, "add", "manifest.yml")
+    run_git(mp, "commit", "-m", "new assembly chain of version 1.1")
+    run_git(mp, "push", "-u", "origin", "refs/heads/ac_1.1")
+
+    # 11th: change branch for next Manifest
+    tsrc_cli.run("manifest", "--branch", "ac_1.1")
+
+    """
+    We are now ready to sync 'ac_1.1' version
+    """
+
+    # 12th: sync the new version
+    tsrc_cli.run("sync")
+
+    # 13th: we want to return back to older assembly chain 'ac_1.0'
+    tsrc_cli.run("manifest", "--branch", "ac_1.0")
+
+    # 14th: sync the older version
+    tsrc_cli.run("sync")
+
+    # 15th: let us see how it end-up when showing the status
+    tsrc_cli.run("status")
+
+    """
+    Now we can see, that all non-Manifest Repositories are
+    1 commit behind. That is exactly right as we have synced
+    to previous assembly chain. It was on the same branch,
+    yet the commit SHA1 was earlier in time
+    """
+
+    # 16th: checkout yet another new 'dev' branch
+    run_git(mp, "checkout", "-b", "dev")
+    ad_hoc_delete_remote_from_manifest(mp / "manifest.yml")
+    run_git(mp, "commit", "-a", "-m", "'new on branch dev'")
+    run_git(mp, "push", "-u", "origin", "refs/heads/dev")
+
+    # 17th: set it for next sync
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # 18th: set wrong SHA1 that is not present
+    _, el_sha1 = run_git_captured(el, "rev-parse", "HEAD")
+    transl_s = "abcdef0123456789"
+    transl_d = "0123456789abcdef"
+    transl_table = str.maketrans(transl_s, transl_d)
+    el_wrong_sha1 = el_sha1.translate(transl_table)
+    ad_hoc_update_sha1_from_manifest(mp / "manifest.yml", el_wrong_sha1)
+
+    # 19th: now we should see demaged SHA1 marked by "!!"
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(
+        r"\* extra-lib     \[ master !! [0-9a-f]{7}                  \]  \( master .1 commit                   == master \) .1 commit"
+    )
+    assert message_recorder.find(
+        r"\* frontend-proj \[ master \?\? [0-9a-f]{7} \(missing remote\) ]  \( master \?\? [0-9a-f]{7} \(missing remote\) << master \) .1 commit"
+    )
+
+    # 20th: extra status test 2 A
+    #   here FM leftover should appear
+    tsrc_cli.run("manifest", "--branch", "ac_1.1")
+    message_recorder.reset()
+    tsrc_cli.run("status", "--show-leftovers-status")
+    if os.name == "nt":
+        assert message_recorder.find(
+            r"\+ inside\\repo_inside                                         \( master ~~ commit  == master \)"
+        )
+    else:
+        assert message_recorder.find(
+            r"\+ inside"
+            + os.sep
+            + r"repo_inside                                         \( master ~~ commit  == master \)"
+        )
+
+    # 21th: test displaying of FM leftover status
+    with open(full1_path / "in_repo.txt", "a") as mod_this_file:
+        mod_this_file.write("it is now modified")
+    message_recorder.reset()
+    tsrc_cli.run("status", "--show-leftovers-status")
+    if os.name == "nt":
+        assert message_recorder.find(
+            r"\+ inside\\repo_inside                                         \( master ~~ commit  << master \) \(dirty\)"
+        )
+    else:
+        assert message_recorder.find(
+            rf"\+ inside{os.sep}repo_inside                                         \( master ~~ commit  << master \) \(dirty\)"
+        )
+
+    # 22th: extra status test 2 B
+    #   even if status of leftover is not displayed,
+    #   the '<<' is correct as the repo is dirty, and thus not same
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    if os.name == "nt":
+        assert message_recorder.find(
+            r"\+ inside\\repo_inside                                         \( master ~~ commit  << master \)"
+        )
+    else:
+        assert message_recorder.find(
+            rf"\+ inside{os.sep}repo_inside                                         \( master ~~ commit  << master \)"
+        )
+
+    # 23th: extra status test 3:
+    #   test comparsion of DM leftover with FM comparsion
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--update", "--force")
+    message_recorder.reset()
+    tsrc_cli.run("status", "--show-leftovers-status")
+    if os.name == "nt":
+        assert message_recorder.find(
+            r"\+ inside\\repo_inside \[ master \]  \( master ~~ commit  << master \) \(dirty\)"
+        )
+    else:
+        assert message_recorder.find(
+            rf"\+ inside{os.sep}repo_inside \[ master \]  \( master ~~ commit  << master \) \(dirty\)"
+        )
+
+    # 24th: get rid of dirty repo
+    run_git(full1_path, "checkout", ".")
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    if os.name == "nt":
+        assert message_recorder.find(
+            r"\+ inside\\repo_inside \[ master \]  \( master ~~ commit  == master \)"
+        )
+    else:
+        assert message_recorder.find(
+            rf"\+ inside{os.sep}repo_inside \[ master \]  \( master ~~ commit  == master \)"
+        )
+    assert message_recorder.find(
+        r"\* backend-proj       \[ master \]  \( master ~~ commit  << master \) .1 commit"
+    )
+
+
+def ad_hoc_add_tag_to_manifest(
+    manifest_path: Path,
+    this_tag: str,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = ruamel.yaml.YAML(typ="rt")
+    parsed = yaml.load(manifest_path.read_text())
+
+    for _, value in parsed.items():
+        if isinstance(value, List):
+            for x in value:
+                if isinstance(x, ruamel.yaml.comments.CommentedMap):
+                    if "dest" in x and x["dest"] == "extra-lib":
+                        x["tag"] = this_tag
+    # write the file down
+    with open(manifest_path, "w") as file:
+        yaml.dump(parsed, file)
+
+
+def ad_hoc_update_sha1_from_manifest(
+    manifest_path: Path,
+    this_sha1: str,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = ruamel.yaml.YAML(typ="rt")
+    parsed = yaml.load(manifest_path.read_text())
+
+    for _, value in parsed.items():
+        if isinstance(value, List):
+            for x in value:
+                if isinstance(x, ruamel.yaml.comments.CommentedMap):
+                    if "dest" in x and x["dest"] == "extra-lib":
+                        if "sha1" in x:
+                            x["sha1"] = this_sha1
+    # write the file down
+    with open(manifest_path, "w") as file:
+        yaml.dump(parsed, file)
+
+
+# flake8: noqa: C901
+def ad_hoc_delete_remote_from_manifest(
+    manifest_path: Path,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = ruamel.yaml.YAML(typ="rt")
+    parsed = yaml.load(manifest_path.read_text())
+
+    for _, value in parsed.items():
+        if isinstance(value, List):
+            for x in value:
+                if isinstance(x, ruamel.yaml.comments.CommentedMap):
+                    if "dest" in x and x["dest"] == "frontend-proj":
+                        if "remotes" in x:
+                            idx_to_del: Optional[int] = None
+                            remotes = x["remotes"]
+                            for idx, _ in enumerate(remotes):
+                                if remotes[idx]["name"] == "origin":
+                                    idx_to_del = idx
+                                    break
+                            if isinstance(idx_to_del, int):
+                                del remotes[idx_to_del]
+                        if "url" in x:
+                            del x["url"]
+
+    # write the file down
+    with open(manifest_path, "w") as file:
+        yaml.dump(parsed, file)

--- a/tsrc/test/cli/test_dump_manifest__filter_bo_manifest.py
+++ b/tsrc/test/cli/test_dump_manifest__filter_bo_manifest.py
@@ -1,0 +1,420 @@
+"""
+Dump Manifest: filter by:
+* considering only Manifest Repo ('--only-manifest')
+* disregarding other then Manifest Repo ('--skip-manifest')
+
+* test if '--only-manifest' fails when no Workspace is there
+* same for '--skip-manifest'
+
+* test if it disregard using '--skip-manifest' and '--only-manifest' at the same time
+"""
+
+from pathlib import Path
+from typing import List
+
+# import pytest
+import ruamel.yaml
+from cli_ui.tests import MessageRecorder
+
+from tsrc.manifest import load_manifest
+from tsrc.test.helpers.cli import CLI
+from tsrc.test.helpers.git_server import GitServer
+from tsrc.workspace_config import WorkspaceConfig
+
+"""
+=================================
+'--skip-manifest' section follows
+"""
+
+
+def test_skip_manifest__on_raw(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if '--skip-manifest' is respected when
+    on RAW dump
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: RAW dump, while skipping manifest
+    * 5th: test if 'manifest' repository is not present
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: RAW dump, while skipping manifest
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--skip-manifest")
+
+    # 5th: test if 'manifest' repository is not present
+    m_path = workspace_path / "manifest.yml"
+    m = load_manifest(m_path)
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            raise Exception("Manifest should not be included")
+
+
+def test_skip_manifest__on_workspace(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if '--skip-manifest' is respected when
+    dump from Workspace (no UPDATE)
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: dump manifest, while skipping DM
+    * 5th: test if 'manifest' repository is not present
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: dump manifest, while skipping DM
+    message_recorder.reset()
+    tsrc_cli.run("dump-manifest", "--skip-manifest")
+    assert message_recorder.find(r"=> Creating NEW file 'manifest\.yml'")
+    assert message_recorder.find(r":: Dump complete")
+
+    # 5th: test if 'manifest' repository is not present
+    m_path = workspace_path / "manifest.yml"
+    m = load_manifest(m_path)
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            raise Exception("Manifest should not be included")
+
+
+def test_skip_manifest__on_workspace__on_update(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if '--skip-manifest' is respected when
+    dump from Workspace no UPDATE
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: change dest of Manifest Repo in Manifest file
+    * 5th: dump manifest, while skipping DM
+    * 6th: verify if Manifest's dest was not updated
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: change dest of Manifest Repo in Manifest file
+    dm_path_file = workspace_path / "manifest" / "manifest.yml"
+    ad_hoc_update_manifest_repo_dest(dm_path_file)
+
+    # 5th: dump manifest, while skipping DM
+    tsrc_cli.run("dump-manifest", "--update", "--skip-manifest", "--force")
+
+    # 6th: verify if Manifest's dest was not updated
+    w_m_path = workspace_path / "manifest" / "manifest.yml"
+    m = load_manifest(w_m_path)
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            raise Exception("Manifest should not be updated")
+
+
+def ad_hoc_update_manifest_repo_dest(
+    manifest_path: Path,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = ruamel.yaml.YAML(typ="rt")
+    parsed = yaml.load(manifest_path.read_text())
+
+    for _, value in parsed.items():
+        if isinstance(value, List):
+            for x in value:
+                if isinstance(x, ruamel.yaml.comments.CommentedMap):
+                    if "dest" in x and x["dest"] == "manifest":
+                        x["dest"] = "manifest_x"
+
+    # write the file down
+    with open(manifest_path, "w") as file:
+        yaml.dump(parsed, file)
+
+
+"""
+=================================
+'--only-manifest' section follows
+"""
+
+
+def test_if_stop_on_mutually_exclusive(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if it stops when using mutually exclusive options:
+    '--skip-manifest' and '--only-manifest' at the same time
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: test conflicting options
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: test conflicting options
+    message_recorder.reset()
+    tsrc_cli.run("dump-manifest", "--only-manifest", "--skip-manifest")
+    assert message_recorder.find(
+        r"Error: '--skip-manifest' and '--only-manifest' are mutually exclusive"
+    )
+
+
+def test_only_manifest__on_workspace(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if '--only-manifest' is respected when
+    dump from Workspace (no UPDATE)
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: dump manifest, while only considering DM
+    * 5th: test if 'manifest' is only Repo in Manifest
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: dump manifest, while only considering DM
+    message_recorder.reset()
+    tsrc_cli.run("dump-manifest", "--only-manifest")
+    assert message_recorder.find(r"=> Creating NEW file 'manifest\.yml'")
+    assert message_recorder.find(r":: Dump complete")
+
+    # 5th: test if 'manifest' is only Repo in Manifest
+    m_path = workspace_path / "manifest.yml"
+    m = load_manifest(m_path)
+    count: int = 0
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            count += 1
+        if repo.dest == "repo1-mr" or repo.dest == "repo2":
+            raise Exception("There should be only Manifest")
+    if count != 1:
+        raise Exception("Manifest processing error")
+    print("DEBUG PATH =", workspace_path)
+
+
+def test_only_manifest__on_raw(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+    Test if '--skip-manifest' is respected when
+    on RAW dump
+
+    Scenario:
+    * 1st: Create repositories
+    * 2nd: add Manifest repository
+    * 3rd: init workspace on master
+    * 4th: RAW dump, while we are interrestend only in manifest's Repo
+    * 5th: test if 'manifest' is only Repo in Manifest
+    """
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: RAW dump, while we are interrestend only in manifest's Repo
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--only-manifest")
+
+    # 5th: test if 'manifest' is only Repo in Manifest
+    m_path = workspace_path / "manifest.yml"
+    m = load_manifest(m_path)
+    count: int = 0
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            count += 1
+        if repo.dest == "repo1-mr" or repo.dest == "repo2":
+            raise Exception("There should be only Manifest")
+    if count != 1:
+        raise Exception("Manifest processing error")
+
+
+def test_only_manifest__on_update(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Description:
+
+    'dump-manifest':
+    test option '--only-manifest' when Workspace dump on UPDATE
+
+    Scenario:
+
+    # 1st: Create repositories
+    # 2nd: add Manifest repository
+    # 3rd: init workspace on master
+    # 4th: change dest of Manifest Repo in Manifest file
+    # 5th: change dest of 'repo2' in Manifest file
+    # 6th: dump-manifest, only manifest, UPDATE existin DM
+    # 7th: test by load_manifest
+    """
+
+    # 1st: Create repositories
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "CMakeLists.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    manifest_url = git_server.manifest_url
+
+    # 2nd: add Manifest repository
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init workspace on master
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: change dest of Manifest Repo in Manifest file
+    dm_path_file = workspace_path / "manifest" / "manifest.yml"
+    ad_hoc_update_manifest_repo_dest(dm_path_file)
+
+    # 5th: change dest of 'repo2' in Manifest file
+    ad_hoc_update_manifest_update_repo2_dest(dm_path_file)
+
+    # 6th: dump-manifest, only manifest, UPDATE existin DM
+    message_recorder.reset()
+    tsrc_cli.run("dump-manifest", "--update", "--only-manifest", "--force")
+    assert message_recorder.find(r"=> UPDATING Deep Manifest on")
+    assert message_recorder.find(r":: Dump complete")
+
+    # 7th: test by load_manifest
+    #   there are Repo's that should and sould not be there
+    w_m_path = workspace_path / "manifest" / "manifest.yml"
+    m = load_manifest(w_m_path)
+    count: int = 0
+    for repo in m.get_repos():
+        if repo.dest == "manifest":
+            count += 1
+        if repo.dest == "repo2_x":
+            count += 2
+        if repo.dest == "repo2":  # it should not be there
+            raise Exception("Manifest should not be updated back to repo2")
+    if count != 3:
+        raise Exception("Manifest update error")
+
+
+def ad_hoc_update_manifest_update_repo2_dest(
+    manifest_path: Path,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = ruamel.yaml.YAML(typ="rt")
+    parsed = yaml.load(manifest_path.read_text())
+
+    for _, value in parsed.items():
+        if isinstance(value, List):
+            for x in value:
+                if isinstance(x, ruamel.yaml.comments.CommentedMap):
+                    if "dest" in x and x["dest"] == "repo2":
+                        x["dest"] = "repo2_x"
+
+    # write the file down
+    with open(manifest_path, "w") as file:
+        yaml.dump(parsed, file)

--- a/tsrc/test/cli/test_dump_manifest_sha1.py
+++ b/tsrc/test/cli/test_dump_manifest_sha1.py
@@ -1,0 +1,118 @@
+"""
+test SHA1 related manifest dump
+like: '--sha1-only'
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from cli_ui.tests import MessageRecorder
+
+from tsrc.manifest import load_manifest_safe_mode
+from tsrc.manifest_common_data import ManifestsTypeOfData
+from tsrc.test.helpers.cli import CLI
+from tsrc.test.helpers.git_server import GitServer
+from tsrc.workspace_config import WorkspaceConfig
+
+
+def test_create_from_workspace__sha1_only(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Create Manifest (by 'dump-manifest')
+    from Workspace while using '--sha1-only' option
+    """
+
+    # 1st: create bunch of repos
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "test.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    git_server.add_repo("repo3")
+    git_server.push_file("repo3", "test.txt")
+    git_server.add_repo("repo4")
+    git_server.push_file("repo4", "test.txt")
+
+    # 2nd: create Manifest repo
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init Workspace
+    manifest_url = git_server.manifest_url
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: create Manifest by '--sha1-only'
+    # tsrc_cli.run("dump-manifest")
+    tsrc_cli.run("dump-manifest", "--sha1-only")
+
+    # 5th: test by load_manifest and pattern match
+    m_file = workspace_path / "manifest.yml"
+    if m_file.is_file() is False:
+        raise Exception("Manifest file does not exists")
+    m = load_manifest_safe_mode(m_file, ManifestsTypeOfData.SAVED)
+    count: int = 0
+    pattern = re.compile("^[0-9a-f]{40}$")
+    for repo in m.get_repos():
+        if repo.sha1 and pattern.match(repo.sha1):
+            count += 1
+
+    if count != 5:
+        raise Exception("mismatch on Manifest SHA1 records")
+
+
+@pytest.mark.last
+def test_update__sha1_only(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Update Deep Manifest (by 'dump-manifest')
+    from Workspace while using '--sha1-only' option
+
+    Even if we did not change any Repo,
+    writing SHA1 to Manifest update it still.
+    """
+
+    # 1st: create bunch of repos
+    git_server.add_repo("repo1-mr")
+    git_server.push_file("repo1-mr", "test.txt")
+    git_server.add_repo("repo2")
+    git_server.push_file("repo2", "test.txt")
+    git_server.add_repo("repo3")
+    git_server.push_file("repo3", "test.txt")
+    git_server.add_repo("repo4")
+    git_server.push_file("repo4", "test.txt")
+
+    # 2nd: create Manifest repo
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    # 3rd: init Workspace
+    manifest_url = git_server.manifest_url
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # 4th: create Manifest by '--sha1-only'
+    # tsrc_cli.run("dump-manifest")
+    tsrc_cli.run("dump-manifest", "--update", "--sha1-only")
+
+    # 5th: test by load_manifest and pattern match
+    m_file = workspace_path / "manifest" / "manifest.yml"
+    if m_file.is_file() is False:
+        raise Exception("Manifest file does not exists")
+    m = load_manifest_safe_mode(m_file, ManifestsTypeOfData.SAVED)
+    count: int = 0
+    pattern = re.compile("^[0-9a-f]{40}$")
+    for repo in m.get_repos():
+        if repo.sha1 and pattern.match(repo.sha1):
+            count += 1
+
+    if count != 5:
+        raise Exception("mismatch on Manifest SHA1 records")


### PR DESCRIPTION
this allows to display position (before or after) for Deep Manifest or Future Manifest

Also fix:
* COMMON PATH calculation for 'dump-manifest' command
* '--show-leftovers-status' allow to display leftover status (if available)
* calculation of COMMON PATH (sometimes it does not shorten the Path as it should)

For 'dump-manifest':
* '--skip-manifest': excludes Manifest Repo (DM) if found
* '--only-manifest': only consider Manifest Repo (DM) if found
* '--sha1-only' put SHA1 record to Manifest for each Repo (--skip-manifest and --only-manifest are respected)