### PR TITLE
'sync': introduce '--switch'

### DIFF
--- a/tsrc/cli/__init__.py
+++ b/tsrc/cli/__init__.py
@@ -173,6 +173,7 @@ def resolve_repos(
     all_cloned: bool,
     include_regex: str = "",
     exclude_regex: str = "",
+    do_switch: bool = False,
     ignore_if_group_not_found: bool = False,
     ignore_group_item: bool = False,
 ) -> List[Repo]:
@@ -192,6 +193,8 @@ def resolve_repos(
         repos = manifest.get_repos(
             groups=groups, ignore_if_group_not_found=ignore_if_group_not_found
         )
+    elif do_switch is True:
+        repos = manifest.get_repos(groups, do_switch)
     elif all_cloned:
         repos = manifest.get_repos(all_=True)
         repos = [repo for repo in repos if (workspace.root_path / repo.dest).exists()]

--- a/tsrc/errors.py
+++ b/tsrc/errors.py
@@ -50,6 +50,12 @@ class LoadManifestSchemaError(Error):
         super().__init__(msg)
 
 
+class LoadManifestSwitchConfigGroupsError(Error):
+    def __init__(self) -> None:
+        msg = "Manifest's Switch Config Groups does not match Groups"
+        super().__init__(msg)
+
+
 class MissingRepoError(Error):
     def __init__(self, dest: str):
         super().__init__(f"No repo found in '{dest}'. Please run `tsrc sync`")

--- a/tsrc/switch.py
+++ b/tsrc/switch.py
@@ -1,0 +1,29 @@
+"""Support for switch in manifest
+
+'switch' can hold part of new default configuration
+and such should only be activated by option '--switch'
+when activated:
+A) and present:
+    it should completely overwrite current configuration.
+B) but not present:
+    the default (empty) configuration should be used
+
+this is particulary usefull when switching
+to new Manifest branch, no need to care about
+current configuration anymore.
+
+NOTE: original handling of configuration
+should be adhered when no '--switch' is provided
+"""
+
+from typing import Any, List, Optional
+
+
+class Switch:
+    def __init__(self, switch_config: Any) -> None:
+        self._config: Optional[Any] = None
+        self._groups: Optional[List[Any]] = None
+        if switch_config:
+            self._config = switch_config.get("config")
+        if self._config:
+            self._groups = self._config.get("groups")

--- a/tsrc/test/cli/test_dump_manifest__filter_bo_manifest.py
+++ b/tsrc/test/cli/test_dump_manifest__filter_bo_manifest.py
@@ -282,7 +282,6 @@ def test_only_manifest__on_workspace(
             raise Exception("There should be only Manifest")
     if count != 1:
         raise Exception("Manifest processing error")
-    print("DEBUG PATH =", workspace_path)
 
 
 def test_only_manifest__on_raw(

--- a/tsrc/test/cli/test_sync__groups.py
+++ b/tsrc/test/cli/test_sync__groups.py
@@ -16,23 +16,15 @@ from tsrc.test.helpers.git_server import GitServer
 from tsrc.workspace_config import WorkspaceConfig
 
 
-def test_sync__group__fm_groups_not_in_config(
+def test_sync__group(
     tsrc_cli: CLI,
     git_server: GitServer,
     workspace_path: Path,
     message_recorder: MessageRecorder,
 ) -> None:
     """
-    BUG: Future Manifest is ignored completely for some reason
-
-    configured Groups [group_3, group_4, group_5]
-    does not match any from Future Manifest and thus Future Manifest
-    block is not even displayed
-
-    How it should be:
-
-    If we do not provide any specific Groups, the configured Groups
-    (from Workspace) should be used + DM Groups + FM Groups
+    General purpos test.
+    Use it as a base for specific tests
     """
 
     sub1_path = workspace_path
@@ -103,7 +95,260 @@ def test_sync__group__fm_groups_not_in_config(
     tsrc_cli.run("sync")
     WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
 
-    # move previous repos so we can determine if they was broad again
+    # move previous repos so we can determine if they ware brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write groups to manifest
+    with open(manifest_path / "manifest.yml", "a") as dm_file:
+        dm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # TODO: do not include this generic test in release
+
+
+def test_sync__group__respect_cmd_line_group_options(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Verify if Groups entered on 'sync' command are respected when:
+    * there are configured Groups,
+    * curently configured Groups does not match any of Future Manifest
+    * updating config is allowed
+    * 'sync' only 1 out-of 2 Groups
+    * thus configuration should contain only 1 Group (verify)
+
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_3")
+    git_server.push_file("repo_3", "repo_3_file.txt")
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_3", ["manifest", "repo_3"])
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they ware brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write groups to manifest
+    with open(manifest_path / "manifest.yml", "a") as dm_file:
+        dm_file.write(
+            "groups:\n  group_1:\n    repos: [repo_1]\n  group_2:\n    repos: [repo_2]"
+        )
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # sync selecting on 1 out of 2 Group
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--groups", "group_1")
+    assert message_recorder.find(r"=> Updating Workspace Groups configuration")
+
+    # test how does 'config.yml' ends up
+    is_ok_count: int = 0
+    with open(Path(".tsrc") / "config.yml", "r") as cfgf:
+        # this_config_lines = cfgf.readlines()
+        this_config_lines = cfgf.read()
+        if "group_2" in this_config_lines:
+            is_ok_count -= 1  # must insist on Error
+        if "group_1" in this_config_lines:
+            is_ok_count += 2
+
+    if is_ok_count != 2:
+        raise AssertionError("config contains wrong groups")
+
+
+def test_sync__group__fm_groups_not_in_config(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Situation:
+
+    * configured Groups [group_3, group_4, group_5]
+    * does not match any from Future Manifest's Groups
+    * switching Manifest branch (to hit such case)
+    * sync (without any Groups)
+
+    Consequences:
+
+    * configured Groups gets updated to: []
+    * all FM repositories will gets synchronized therefore
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_3")
+    git_server.push_file("repo_3", "repo_3_file.txt")
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_3", ["manifest", "repo_3"])
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    # tsrc_cli.run("init", "--branch", "master", manifest_url)
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_3",
+        "group_4",
+        "group_5",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they ware brought back again
     shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
 
     """
@@ -140,6 +385,29 @@ def test_sync__group__fm_groups_not_in_config(
     assert message_recorder.find(r"- repo_1   \( master << ::: \)")
     assert message_recorder.find(r"\+ repo_2   \( master == master \)")
 
+    message_recorder.reset()
+    tsrc_cli.run("sync")
+    assert message_recorder.find(r"=> Updating Workspace Groups configuration")
+
+    # test how does 'config.yml' ends up
+    with open(Path(".tsrc") / "config.yml", "r") as cfgf:
+        this_config_lines = cfgf.read()
+        if (
+            "group_3" in this_config_lines
+            or "group_4" in this_config_lines  # noqa: 503
+            or "group_5" in this_config_lines  # noqa: 503
+            or "group_all" in this_config_lines  # noqa: 503
+        ):
+            raise AssertionError("config contains wrong groups")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"=> Before possible GIT statuses, Workspace reports:")
+    assert message_recorder.find(r"=> Destination")
+    assert not message_recorder.find(r"=> Destination ")
+    assert message_recorder.find(r"\* repo_1 master")
+    assert message_recorder.find(r"\* repo_2 master")
+
 
 def test_sync__group__dm_group_found_but_no_item_intersection_with_workspace(
     tsrc_cli: CLI,
@@ -148,14 +416,34 @@ def test_sync__group__dm_group_found_but_no_item_intersection_with_workspace(
     message_recorder: MessageRecorder,
 ) -> None:
     """
-    Test corner cases when ready to 'sync'
-    (manifest_branch != manifest_branch_0)
+    Test corner cases when changing Manifest branch and 'sync'
 
-    Cases
+    Situation:
 
-    1st: DM has intersectioned Group, however it items does not intersect
-        - in such case, the DM item will be displayed as leftover
+    * configured Groups: ['group_3', 'group_4', 'group_5']
+    * FM is with overlaping Group: 'group_3', but with different Repo (as item)
+    * FM has also 'group_all' covering all new Repos
+    * set new Manifest branch
+    * sync only Group 'group_3'
 
+    Consequences:
+
+    * While FM has Group ('group_all') that covers all Repos, such Group is not configured.
+    Only 'group_3', therefore
+    * Configured Groups changes to only 'group_3'
+    * BUT!!! as 'tsrc status' predicst FM only when no Groups are filtered-out, thus
+    it shows that 2 Repos will be synced instead of 1, which is ok.
+    (currently there is no way how to tell 'status' what Groups we would like to syncing,
+    thus calculation of FM Repos can only be without filtering-out Groups)
+    * when DM (finaly) does have overlaping Group ('group_3') with Repo that is not in the
+    Workspace, DM Repo will be displayed as DM leftover.
+
+    Conclusion:
+
+    This behavior seems correct, but without way to reset Groups, we are calling for
+    future troubles when Groups may overlap and when at least one match, Groups will
+    be configured with match. '--no-update-config' will not help as old Groups may
+    cause even more harm.
     """
 
     sub1_path = workspace_path
@@ -222,11 +510,20 @@ def test_sync__group__dm_group_found_but_no_item_intersection_with_workspace(
 
     # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
 
-    tsrc_cli.run("init", "--branch", "master", manifest_url)
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_3",
+        "group_4",
+        "group_5",
+    )
     tsrc_cli.run("sync")
     WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
 
-    # move previous repos so we can determine if they was broad again
+    # move previous repos so we can determine if they ware brought back again
     shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
 
     """
@@ -260,6 +557,7 @@ def test_sync__group__dm_group_found_but_no_item_intersection_with_workspace(
     #   according to Future Manifest's defined Groups.
     message_recorder.reset()
     tsrc_cli.run("status")
+
     assert message_recorder.find(
         r"=> Destination \[Deep Manifest description\] \(Future Manifest description\)"
     )
@@ -290,6 +588,33 @@ def test_sync__group__dm_group_found_but_no_item_intersection_with_workspace(
     )
     assert message_recorder.find(r"\* repo_4              \(        << master \)")
     assert message_recorder.find(r"- repo_1   \[ master \] \( master << ::: \)")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync")
+    assert message_recorder.find(r"=> Updating Workspace Groups configuration")
+
+    # test how does 'config.yml' ends up
+    is_ok: int = 0
+    with open(Path(".tsrc") / "config.yml", "r") as cfgf:
+        this_config_lines = cfgf.read()
+        if (
+            "group_4" in this_config_lines
+            or "group_5" in this_config_lines  # noqa: 503
+            or "group_all" in this_config_lines  # noqa: 503
+        ):
+            raise AssertionError("config contains wrong groups")
+        else:
+            if "group_3" in this_config_lines:
+                is_ok += 1
+
+    if is_ok != 1:
+        raise AssertionError("config contains wrong groups")
+
+    # just 1 repo should be synced
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_1 master")
+    assert not message_recorder.find(r"\* repo_[2-9]")
 
 
 def test_sync__group__fm_no_groups(
@@ -372,7 +697,7 @@ def test_sync__group__fm_no_groups(
     tsrc_cli.run("sync")
     WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
 
-    # move previous repos so we can determine if they was broad again
+    # move previous repos so we can determine if they ware brought back again
     shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
 
     """
@@ -410,3 +735,12 @@ def test_sync__group__fm_no_groups(
     assert message_recorder.find(r"\* repo_5              \(        << master \)")
     assert message_recorder.find(r"- repo_1   \[ master \] \( master << ::: \)")
     assert message_recorder.find(r"\+ repo_2   \[ master \] \( master == master \)")
+
+    tsrc_cli.run("sync")
+
+    # at last verify status
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_1 master")
+    assert message_recorder.find(r"\* repo_2 master")
+    assert not message_recorder.find(r"\* repo_[3-9]")

--- a/tsrc/test/cli/test_sync__switch.py
+++ b/tsrc/test/cli/test_sync__switch.py
@@ -1,0 +1,1207 @@
+"""
+tests dedicated to 'sync --switch' mode
+
+in such mode, the sync is about to change configuration for some
+items like 'groups'. if such configuration is not found
+in the Manifest file, and '--switch' is used non the less, the
+default configuration for such configuration items is used.
+(the default configuration is no Groups)
+
+changing configuration is particulary usefull when we want to
+switch to different manifest branch, that may have majority
+of Repos/Groups different. this allows to not risk that such
+current configuration will interfere with the Manifest's
+own Groups settings (like it should not)
+
+while without '--switch' the sync mechanizm consider
+current configuration and new Manifest in default way
+to keep prefered behavior by default.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from cli_ui.tests import MessageRecorder
+
+from tsrc.git import run_git
+from tsrc.test.helpers.cli import CLI
+from tsrc.test.helpers.git_server import GitServer
+from tsrc.workspace_config import WorkspaceConfig
+
+
+def test_sync__switch__cfg_groups__to__no_m_sw_cfg_groups__with_cmd_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    Configured groups --> no manifest switch option
+
+    Conditions:
+
+    * Workspace with configured groups
+    * FM does not contain any 'switch' part
+    * FM groups does not intersect
+
+    Outcome:
+
+    * Workspace configuration of groups cleared
+    """
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+    git_server.add_group("group_6", ["manifest", "repo_6"])
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_4",
+        "group_5",
+        "group_6",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # now with requrested Groups
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch", "--groups", "group_all")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    assert message_recorder.find(r"\* repo_[1-2] master")
+    assert not message_recorder.find(r"\* repo_[3-9]")
+
+
+def test_sync__switch__cfg_groups__to__empty_group_m_switch(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    Configured groups --> empty 'switch' groups config
+
+    Conditions:
+
+    * Workspace with configured groups
+    * FM groups does not intersect
+    * empty ([]) 'switch' configuration
+
+    Outcome:
+
+    * synced all repos as Workspace configuration should be reset
+    which means Groups should be: '[]'
+    """
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+    git_server.add_group("group_6", ["manifest", "repo_6"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_4",
+        "group_5",
+        "group_6",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+        fm_file.write("switch:\n  config:\n    groups: []\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # now with requrested Groups
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    assert message_recorder.find(r"\* repo_[1-3] master")
+    assert not message_recorder.find(r"\* repo_[4-9]")
+
+
+def test_sync__switch__cfg_groups__to__no_m_sw_cfg_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    Configured groups --> no manifest switch option
+
+    Conditions:
+
+    * Workspace with configured groups
+    * FM does not contain any 'switch' part
+    * FM groups does not intersect
+
+    Outcome:
+
+    * Workspace configuration of groups cleared
+    """
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+    git_server.add_group("group_6", ["manifest", "repo_6"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_4",
+        "group_5",
+        "group_6",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch")
+
+    # we are not updating 'repos_groups' (Groups configuration) even when on
+    # '--switch' due to there is no change from '[]' to '[]'
+    assert message_recorder.find(
+        r"=> No Manifest's switch configuration found, using default configuration"
+    )
+    assert message_recorder.find(r"=> Updating Workspace Groups configuration")
+    assert not message_recorder.find(
+        r"=> Leaving Workspace Groups configuration intact"
+    )
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    assert message_recorder.find(r"\* repo_[1-3] master")
+    assert not message_recorder.find(r"\* repo_[4-9]")
+
+
+def test_sync__switch__not_cfg_groups__to__m_sw_cfg_groups__with_cmd_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    NOT configured groups --> manifest (switch option) configured groups
+    while using only selected group
+
+    Conditions:
+
+    * Workspace without configured Groups
+    * FM contains Groups and correct 'switch' part
+    * using 'sync' with '--groups' to select only one group
+
+    Outcome:
+
+    * synced to manifest to selected group (as it match switch configuration)
+    * workspace config updated according to selected group
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+        fm_file.write("  group_b:\n    repos: [repo_2]\n")
+        fm_file.write("switch:\n  config:\n    groups:\n      - group_a\n")
+        fm_file.write("      - group_b\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "group_a and group_b")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # now with requrested Groups
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch", "--group", "group_b")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_2 master")
+    assert not message_recorder.find(r"\* repo_1")
+    assert not message_recorder.find(r"\* repo_[3-9]")
+
+
+def test_sync__switch__not_cfg_groups__to__m_sw_cfg_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    NOT configured groups --> manifest (switch option) configured groups
+
+    Conditions:
+
+    * Workspace without configured Groups
+    * FM contains Groups and correct 'switch' part
+
+    Outcome:
+
+    * synced to manifest configured groups
+    * workspace config updated according to manifest switch part
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+        fm_file.write("switch:\n  config:\n    groups:\n      - group_a")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # now with requrested Groups
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_1 master")
+    assert not message_recorder.find(r"\* repo_[2-9]")
+
+
+@pytest.mark.last
+def test_sync__switch__cfg_groups__to__m_sw_cfg_groups__with_cmd_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    configured groups --> manifest (switch option) configured groups :: with cmd groups
+
+    -------
+    CASE 1: no match
+
+    Conditions:
+
+    * groups are configured in Workspace
+    * FM contains different groups
+    * FM contains 'switch' part with properly set one group 'group_a'
+    that does not match anywhere
+    * along with '--switch', the '--group group_b' is requested
+
+    Outcome:
+
+    * 'group_a' and 'group_b' does not have intersection, thus nothing
+    is synced, the 'sync' is ignored, Error message is printed
+
+    -------
+    CASE 2: match different group (not from 'swtich'):
+
+    * let us update 'switch' configuration with 'group_all', commit, push
+
+    Situation:
+
+    * now STILL!!! 'group_a' + 'group_all' does not have intersection with
+    'group_b', however all items of 'group_b' ('repo_2') is covered by
+    'group_all'. and it this case we can allow to set 'group_b', due to
+    it is fully covered in 'switch' configuration
+
+    Outcome:
+
+    * Workspace gets synced to 'group_b' successfully, config is also updated
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+    git_server.add_group("group_6", ["manifest", "repo_6"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_4",
+        "group_5",
+        "group_6",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # - CASE 1: --------------------------------------------
+    # set 'swtich' configuration only to contain 'group_a'
+    # while we want only 'group_be'. here 'group_a' and 'group_b'
+    # does not have (full) intersection, therefore there is
+    # no match and Error is printed
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+        fm_file.write("  group_b:\n    repos: [repo_2]\n")
+        fm_file.write("switch:\n  config:\n    groups:\n      - group_a\n")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "case 1: no match, error")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # here: 'group_a' does not have intersection with its Repos
+    #   to 'group_b', therefore no match has to be reported
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch", "--groups", "group_b")
+    assert message_recorder.find(
+        r"Error: Provided Groups does not match any in the Manifest"
+    )
+
+    # - CASE 2: ---------------------------------------------
+    # now another case of the same, but here the 'switch'
+    # groups can fully cover Repos (items) of 'group_b'
+    # due to 'group_a' and 'group_all' cover 'repo2' as it is
+    # in 'group_all'. so we cal clrearly set 'group_b' fully
+
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("      - group_all")
+
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "case 2: match group not in switch cfg")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    tsrc_cli.run("sync", "--switch")
+    tsrc_cli.run("manifest", "--branch", "master")
+    tsrc_cli.run("sync", "--switch")
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # it should be accepted correctly even if 'group_b'
+    #   is not found in 'switch' section
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch", "--groups", "group_b")
+    assert message_recorder.find(r"=> Using Manifest's switch configuration")
+    assert message_recorder.find(r"=> Updating Workspace Groups configuration")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_2 master")
+    assert not message_recorder.find(r"\* repo_[3-9]")
+    assert not message_recorder.find(r"\* repo_1")
+
+    # test config as well
+    is_ok_count: int = 0
+    with open(Path(".tsrc") / "config.yml", "r") as cfgf:
+        # this_config_lines = cfgf.readlines()
+        this_config_lines = cfgf.read()
+        if "group_b" in this_config_lines:
+            is_ok_count += 1  # must insist on Error
+        elif "group_" in this_config_lines:  # any other group
+            is_ok_count -= 2
+
+    if is_ok_count != 1:
+        raise AssertionError("config contains wrong groups")
+
+
+def test_sync__switch__cfg_groups__to__m_sw_cfg_groups(
+    tsrc_cli: CLI,
+    git_server: GitServer,
+    workspace_path: Path,
+    message_recorder: MessageRecorder,
+) -> None:
+    """
+    Alias:
+
+    configured groups --> manifest (switch option) configured groups
+
+    Conditions:
+
+    * groups are configured in Workspace
+    * FM contains different groups
+    * FM contains 'switch' part with properly set one group 'group_a'
+    that does not match anywhere
+
+    Outcome:
+
+    * synced to group: 'group_a'
+    * workspace config updated to 'group_a' only
+    """
+
+    sub1_path = workspace_path
+    sub1_1_path = Path("repo_1")
+    os.mkdir(sub1_1_path)
+    os.chdir(sub1_1_path)
+    full_sub1_path: Path = Path(os.path.join(workspace_path, sub1_path, sub1_1_path))
+    run_git(full_sub1_path, "init")
+    sub1_1_1_file = Path("in_repo.txt")
+    sub1_1_1_file.touch()
+    run_git(full_sub1_path, "add", "in_repo.txt")
+    run_git(full_sub1_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub1_1_url = git_server.get_url(str(sub1_1_path))
+    sub1_1_url_path = Path(git_server.url_to_local_path(sub1_1_url))
+    sub1_1_url_path.mkdir()
+    run_git(sub1_1_url_path, "init", "--bare")
+    run_git(full_sub1_path, "remote", "add", "origin", sub1_1_url)
+    run_git(full_sub1_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub2_path = workspace_path
+    sub2_1_path = Path("repo_2")
+    os.mkdir(sub2_1_path)
+    os.chdir(sub2_1_path)
+    full_sub2_path: Path = Path(os.path.join(workspace_path, sub2_path, sub2_1_path))
+    run_git(full_sub2_path, "init")
+    sub2_1_1_file = Path("in_repo.txt")
+    sub2_1_1_file.touch()
+    run_git(full_sub2_path, "add", "in_repo.txt")
+    run_git(full_sub2_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub2_1_url = git_server.get_url(str(sub2_1_path))
+    sub2_1_url_path = Path(git_server.url_to_local_path(sub2_1_url))
+    sub2_1_url_path.mkdir()
+    run_git(sub2_1_url_path, "init", "--bare")
+    run_git(full_sub2_path, "remote", "add", "origin", sub2_1_url)
+    run_git(full_sub2_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    sub3_path = workspace_path
+    sub3_1_path = Path("repo_3")
+    os.mkdir(sub3_1_path)
+    os.chdir(sub3_1_path)
+    full_sub3_path: Path = Path(os.path.join(workspace_path, sub3_path, sub3_1_path))
+    run_git(full_sub3_path, "init")
+    sub3_1_1_file = Path("in_repo.txt")
+    sub3_1_1_file.touch()
+    run_git(full_sub3_path, "add", "in_repo.txt")
+    run_git(full_sub3_path, "commit", "in_repo.txt", "-m", "adding in_repo.txt file")
+    # take care of remote
+    sub3_1_url = git_server.get_url(str(sub3_1_path))
+    sub3_1_url_path = Path(git_server.url_to_local_path(sub3_1_url))
+    sub3_1_url_path.mkdir()
+    run_git(sub3_1_url_path, "init", "--bare")
+    run_git(full_sub3_path, "remote", "add", "origin", sub3_1_url)
+    run_git(full_sub3_path, "push", "-u", "origin", "refs/heads/master")
+
+    os.chdir(workspace_path)
+
+    tsrc_cli.run("dump-manifest", "--raw", ".", "--save-to", "later_manifest.yml")
+
+    """
+    ====================================================
+    now: let us create Workspace with Repos and Manifest
+    """
+
+    git_server.add_repo("repo_4")
+    git_server.push_file("repo_4", "repo_4_file.txt")
+    git_server.add_repo("repo_5")
+    git_server.push_file("repo_5", "repo_5_file.txt")
+    git_server.add_repo("repo_6")
+    git_server.push_file("repo_6", "repo_6_file.txt")
+    manifest_url = git_server.manifest_url
+
+    git_server.add_manifest_repo("manifest")
+    git_server.manifest.change_branch("master")
+
+    git_server.add_group("group_4", ["manifest", "repo_4"])
+    git_server.add_group("group_5", ["manifest", "repo_5"])
+    git_server.add_group("group_6", ["manifest", "repo_6"])
+
+    # git_server.manifest.configure_group("group_3", ["manifest", "repo_3"])
+
+    tsrc_cli.run(
+        "init",
+        "--branch",
+        "master",
+        manifest_url,
+        "--group",
+        "group_4",
+        "group_5",
+        "group_6",
+    )
+    tsrc_cli.run("sync")
+    WorkspaceConfig.from_file(workspace_path / ".tsrc" / "config.yml")
+
+    # move previous repos so we can determine if they were brought back again
+    shutil.move(workspace_path / "repo_1", workspace_path / "__repo_1")
+    shutil.move(workspace_path / "repo_2", workspace_path / "__repo_2")
+    shutil.move(workspace_path / "repo_3", workspace_path / "__repo_3")
+
+    """
+    ==========
+    now: introduce previous manifest
+    """
+
+    shutil.copyfile("later_manifest.yml", Path("manifest") / "manifest.yml")
+    manifest_path = workspace_path / "manifest"
+
+    # write 'groups' and 'switch' to manifest
+    with open(manifest_path / "manifest.yml", "a") as fm_file:
+        fm_file.write("groups:\n  group_all:\n    repos: [repo_1, repo_2]\n")
+        fm_file.write("  group_a:\n    repos: [repo_1]\n")
+        fm_file.write("switch:\n  config:\n    groups:\n      - group_a")
+
+    run_git(manifest_path, "checkout", "-b", "dev")
+    run_git(manifest_path, "add", "manifest.yml")
+    run_git(manifest_path, "commit", "-m", "new version - dev")
+    run_git(manifest_path, "push", "-u", "origin", "dev")
+
+    # set to new manifest branch
+    tsrc_cli.run("manifest", "--branch", "dev")
+
+    # now with requrested Groups
+    message_recorder.reset()
+    tsrc_cli.run("status")
+
+    message_recorder.reset()
+    tsrc_cli.run("sync", "--switch")
+
+    message_recorder.reset()
+    tsrc_cli.run("status")
+    assert message_recorder.find(r"\* repo_1 master")
+    assert not message_recorder.find(r"\* repo_[2-9]")

--- a/tsrc/test/cli/test_sync_extended.py
+++ b/tsrc/test/cli/test_sync_extended.py
@@ -92,9 +92,9 @@ def test_sync_on_groups_intersection__case_1(
     message_recorder.reset()
     tsrc_cli.run("status")
     assert message_recorder.find(r"\* manifest \[ master \]= master ~~ MANIFEST")
-    assert message_recorder.find(r"\* repo_1   \[ master \]  master")
+    assert not message_recorder.find(r"\* repo_1")
     assert message_recorder.find(r"\* repo_3   \[ master \]  master")
-    assert message_recorder.find(r"\* repo_5   \[ master \]  master")
+    assert not message_recorder.find(r"\* repo_5")
 
 
 def test_sync_on_groups_intersection__case_2(
@@ -278,17 +278,22 @@ def test_sync_on_groups_intersection__case_3_a(
     # ================== from here it is different ==================
     # 10th: sync (use specific case for given test)
     # case: 3 A
-    # here: if we do not provide '--ignore-missing-groups'
-    #   we will end up with error that 'group_2' is not found
-    tsrc_cli.run("sync", "--ignore-missing-groups")
+    #   we do not need '--ignore-missing-groups'
+    #   as by default configured groups are updated
+    #   but if we disable that, we still need to ignore missing groups
+    tsrc_cli.run("sync", "--no-update-config", "--ignore-missing-groups")
 
     # 11th: veryfy by 'status' output
     message_recorder.reset()
-    tsrc_cli.run("status")
+    tsrc_cli.run("status", "--ignore-missing-groups")
+    return
     assert message_recorder.find(r"\* manifest \[ master \]= master ~~ MANIFEST")
-    assert message_recorder.find(r"\* repo_1   \[ master \]  master")
+    assert not message_recorder.find(r"\* repo_1")
     assert message_recorder.find(r"\* repo_3   \[ master \]  master")
-    assert message_recorder.find(r"\* repo_5   \[ master \]  master")
+    assert not message_recorder.find(r"\* repo_5")
+    assert message_recorder.find(r"\+ repo_4   \[ master \]  master")
+    assert message_recorder.find(r"\+ repo_2   \[ master \]  master")
+    assert message_recorder.find(r"\+ repo_6   \[ master \]  master")
 
 
 def test_sync_on_groups_intersection__case_3_b(

--- a/tsrc/test/test_manifest.py
+++ b/tsrc/test/test_manifest.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import pytest
 import ruamel.yaml
 
-from tsrc.errors import Error, InvalidConfigError
+from tsrc.errors import Error, InvalidConfigError, LoadManifestSwitchConfigGroupsError
 from tsrc.file_system import Copy, Link
 from tsrc.manifest import Manifest, RepoNotFound, load_manifest
 from tsrc.repo import Remote, Repo
@@ -251,6 +251,70 @@ groups:
         "linux1",
         "linux2",
     ]
+
+
+def test_switch_and_groups__is_error__on_switch() -> None:
+    contents = """
+repos:
+  - { dest: any, url: any.com }
+  - { dest: linux1, url: linux1.com }
+  - { dest: linux2, url: linux2.com }
+
+groups:
+  linux:
+    repos: [linux1, linux2]
+  foo_gr:
+    repos: [any, linux1]
+
+switch:
+  config:
+    groups: [linux, tux]
+"""
+    try:
+        parse_manifest(contents)
+    except LoadManifestSwitchConfigGroupsError:
+        pass
+    else:
+        raise AssertionError()
+
+
+def test_switch_and_groups__is_error__missing_groups() -> None:
+    contents = """
+repos:
+  - { dest: any, url: any.com }
+  - { dest: linux1, url: linux1.com }
+  - { dest: linux2, url: linux2.com }
+
+switch:
+  config:
+    groups: [linux]
+"""
+    try:
+        parse_manifest(contents)
+    except LoadManifestSwitchConfigGroupsError:
+        pass
+    else:
+        raise AssertionError()
+
+
+def test_switch_and_groups() -> None:
+    contents = """
+repos:
+  - { dest: any, url: any.com }
+  - { dest: linux1, url: linux1.com }
+  - { dest: linux2, url: linux2.com }
+
+groups:
+  linux:
+    repos: [linux1, linux2]
+  foo_gr:
+    repos: [any, linux1]
+
+switch:
+  config:
+    groups: [linux]
+"""
+    parse_manifest(contents)
 
 
 def test_inclusion(repos_getter: ReposGetter) -> None:

--- a/tsrc/workspace.py
+++ b/tsrc/workspace.py
@@ -2,7 +2,7 @@
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import cli_ui as ui
 import ruamel.yaml
@@ -81,8 +81,82 @@ class Workspace:
 
         self.local_manifest.update(url=manifest_url, branch=manifest_branch)
 
+    def _must_match_all_group_items(
+        self, manifest: Manifest, groups: List[str], found_groups: List[str]
+    ) -> bool:
+        # go through all items in 'groups' as all items on each group has to
+        # be found in 'found_groups' items
+        need_items: List[str] = []  # all the items of all the 'groups'
+        found_items: List[str] = []  # all that are found
+        if manifest.group_list and manifest.group_list.groups:
+            for name, group in manifest.group_list.groups.items():
+                if name in groups:
+                    need_items += group.elements
+                if name in found_groups:
+                    found_items += group.elements
+        if set(need_items) == set(need_items).intersection(found_items):
+            return True
+        return False
+
+    def update_config_on_switch(
+        self,
+        manifest: Manifest,
+        found_groups: Optional[List[str]],
+        groups: Optional[List[str]],
+    ) -> Union[bool, None]:
+        # we are switching, so Groups will be new in config
+        ret_val: Union[bool, None] = None
+        manifest = self.local_manifest.get_manifest()
+        if manifest._switch and manifest._switch._groups:
+            if found_groups and groups:
+                matched_groups = list(
+                    set(manifest._switch._groups).intersection(found_groups)
+                )
+                if matched_groups:
+                    self.config.repo_groups = matched_groups
+                    ret_val = True
+                else:
+                    # we may accept even Group, that does not match
+                    # only if all items of such group
+                    # can be found in 'groups' items
+                    if (
+                        self._must_match_all_group_items(
+                            manifest, groups, manifest._switch._groups
+                        )
+                        is True
+                    ):
+                        self.config.repo_groups = groups
+                        ret_val = True
+                    else:
+                        return None
+            elif groups:
+                return None
+            else:
+                self.config.repo_groups = list(manifest._switch._groups)
+                ret_val = True
+            if ret_val is True:
+                ui.info_2("Using Manifest's switch configuration")
+        else:
+            if found_groups and groups:
+                self.config.repo_groups = found_groups
+                ret_val = True
+            elif groups:
+                return None
+            else:
+                self.config.repo_groups = []
+                ret_val = True
+                ui.info_2(
+                    "No Manifest's switch configuration found, using default configuration"
+                )
+                ret_val = True
+        self.config.save_to_file(self.cfg_path)
+        return ret_val
+
     def update_config_repo_groups(
-        self, groups: Optional[List[str]], ignore_group_item: bool = False
+        self,
+        groups: Optional[List[str]],
+        ignore_group_item: bool = False,
+        want_groups: Optional[List[str]] = None,
     ) -> None:
         if groups:
             self.config.repo_groups = groups
@@ -95,7 +169,16 @@ class Workspace:
             else:
                 local_manifest = self.local_manifest.get_manifest()
             if local_manifest.group_list:
-                self.config.repo_groups = list(local_manifest.group_list.groups)
+                possible_groups = list(local_manifest.group_list.groups)
+                if want_groups:
+                    self.config.repo_groups = list(
+                        set(want_groups).intersection(possible_groups)
+                    )
+                else:  # keep those that are possible & configured
+                    self.config.repo_groups = list(
+                        set(self.config.repo_groups).intersection(possible_groups)
+                    )
+
                 self.config.save_to_file(self.cfg_path)
 
     def clone_missing(self, *, num_jobs: int = 1) -> None:


### PR DESCRIPTION
'--swich' option allows to use 'switch' configuration from Manifest. Currently only 'repo_groups' is supported
if Manifest does not contain 'switch' part, workspace configuration is reset to default.